### PR TITLE
update module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ def handle_callback
 
     # Create a new token to save into a store
     token = Procore::Auth::Token.new(
-      access_token: auth_hash["token"]
-      refresh_token: auth_hash["refresh_token"],
-      expires_at: auth_hash["expires_at"]
+      access_token: auth_hash["credentials"]["token"]
+      refresh_token: auth_hash["credentials"]["refresh_token"],
+      expires_at: auth_hash["credentials"]["expires_at"]
     )
 
     store = Procore::Auth::Stores::Session.new(session: session)


### PR DESCRIPTION
When making a request using the suggested code, it throws an error because Procore::Auth::Stores::SessionStore is no longer the correct name of the class.

Changed to Procore::Auth::Stores::Session to solve this confusion.