### PR TITLE
feat: Wrap AccessTokenCredentials in our own errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Wrap `AccessTokenCredentials` external errors with our own errors
+
 ## 0.6.7 (January 04, 2018)
 
 * Allow gem to be pushed to RubyGems

--- a/lib/procore/auth/access_token_credentials.rb
+++ b/lib/procore/auth/access_token_credentials.rb
@@ -11,14 +11,28 @@ module Procore
       end
 
       def refresh(token:, refresh:)
-        token = OAuth2::AccessToken.new(client, token, refresh_token: refresh)
-        new_token = token.refresh!
+        begin
+          token = OAuth2::AccessToken.new(client, token, refresh_token: refresh)
+          new_token = token.refresh!
 
-        Procore::Auth::Token.new(
-          access_token: new_token.token,
-          refresh_token: new_token.refresh_token,
-          expires_at: new_token.expires_at,
-        )
+          Procore::Auth::Token.new(
+            access_token: new_token.token,
+            refresh_token: new_token.refresh_token,
+            expires_at: new_token.expires_at,
+          )
+
+        rescue OAuth2::Error => e
+          raise OAuthError.new(e.description, response: e.response)
+
+        rescue Faraday::ConnectionFailed => e
+          raise APIConnectionError.new("Connection Error: #{e.message}")
+
+        rescue URI::BadURIError
+          raise OAuthError.new(
+            "Host is not a valid URI. Check your host option to make sure it " \
+            "is a properly formed url",
+          )
+        end
       end
 
       private

--- a/lib/procore/auth/client_credentials.rb
+++ b/lib/procore/auth/client_credentials.rb
@@ -15,27 +15,29 @@ module Procore
       end
 
       def refresh(token: nil, refresh: nil)
-        new_token = client
-          .client_credentials
-          .get_token({}, { auth_scheme: :request_body })
+        begin
+          new_token = client
+            .client_credentials
+            .get_token({}, { auth_scheme: :request_body })
 
-        Procore::Auth::Token.new(
-          access_token: new_token.token,
-          refresh_token: new_token.refresh_token,
-          expires_at: new_token.expires_at,
-        )
+          Procore::Auth::Token.new(
+            access_token: new_token.token,
+            refresh_token: new_token.refresh_token,
+            expires_at: new_token.expires_at,
+          )
 
-      rescue OAuth2::Error => e
-        raise OAuthError.new(e.description, response: e.response)
+        rescue OAuth2::Error => e
+          raise OAuthError.new(e.description, response: e.response)
 
-      rescue Faraday::ConnectionFailed => e
-        raise APIConnectionError.new("Connection Error: #{e.message}")
+        rescue Faraday::ConnectionFailed => e
+          raise APIConnectionError.new("Connection Error: #{e.message}")
 
-      rescue URI::BadURIError
-        raise OAuthError.new(
-          "Host is not a valid URI. Check your host option to make sure it "   \
-          "is a properly formed url"
-        )
+        rescue URI::BadURIError
+          raise OAuthError.new(
+            "Host is not a valid URI. Check your host option to make sure it "   \
+            "is a properly formed url"
+          )
+        end
       end
 
       private

--- a/test/procore/auth/access_token_credentials_test.rb
+++ b/test/procore/auth/access_token_credentials_test.rb
@@ -33,4 +33,109 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
     assert_equal "New Refresh", new_token.refresh_token
     refute new_token.expired?
   end
+
+  def test_oauth_client_error_with_html
+    stub_request(:post, "https://procore.example.com/oauth/token").
+      with(body: {
+        "client_id" => "id",
+        "client_secret" => "secret",
+        "grant_type" => "refresh_token",
+        "refresh_token" => "refresh",
+      })
+      .to_return(
+        status: 500,
+        body: "<html><body><h1>This is very bad</h1></body></html>",
+        headers: { "Content-Type" => "text/html" },
+      )
+
+    credentials = Procore::Auth::AccessTokenCredentials.new(
+      client_id: "id",
+      client_secret: "secret",
+      host: "https://procore.example.com"
+    )
+
+    error = assert_raises Procore::OAuthError do
+      credentials.refresh(token: "token", refresh: "refresh")
+    end
+
+    assert_equal error.response.code, 500
+    assert_equal error.response.body, "<html><body><h1>This is very bad</h1></body></html>"
+    assert_equal error.response.headers, { "content-type" => "text/html" }
+    assert_nil error.response.request.path
+    assert_equal error.response.request.options, {}
+  end
+
+  def test_oauth_client_error_with_json
+    stub_request(:post, "https://procore.example.com/oauth/token").
+      with(body: {
+        "client_id" => "id",
+        "client_secret" => "secret",
+        "grant_type" => "refresh_token",
+        "refresh_token" => "refresh",
+      })
+      .to_return(
+        status: 500,
+        body: { error: "Some bad error" }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+    credentials = Procore::Auth::AccessTokenCredentials.new(
+      client_id: "id",
+      client_secret: "secret",
+      host: "https://procore.example.com"
+    )
+
+    error = assert_raises Procore::OAuthError do
+      credentials.refresh(token: "token", refresh: "refresh")
+    end
+
+    assert_equal error.response.code, 500
+    assert_equal error.response.body, { "error" => "Some bad error" }
+    assert_equal error.response.headers, { "content-type" => "application/json" }
+    assert_nil error.response.request.path
+    assert_equal error.response.request.options, {}
+  end
+
+  def test_connection_failed_error
+    stub_request(:post, "https://procore.example.com/oauth/token").
+      with(body: {
+        "client_id" => "id",
+        "client_secret" => "secret",
+        "grant_type" => "refresh_token",
+        "refresh_token" => "refresh",
+      }).to_timeout
+
+    credentials = Procore::Auth::AccessTokenCredentials.new(
+      client_id: "id",
+      client_secret: "secret",
+      host: "https://procore.example.com"
+    )
+
+    assert_raises Procore::APIConnectionError do
+      credentials.refresh(token: "token", refresh: "refresh")
+    end
+  end
+
+  def test_bad_uri_error
+    stub_request(:post, "https://procore.example.com/oauth/token")
+      .with(
+        body: {
+          "client_id" => "id",
+          "client_secret" => "secret",
+          "grant_type" => "client_credentials",
+        },
+      )
+
+    credentials = Procore::Auth::AccessTokenCredentials.new(
+      client_id: "id",
+      client_secret: "secret",
+      host: "invalid-uri",
+    )
+
+    error = assert_raises Procore::OAuthError do
+      credentials.refresh(token: "token", refresh: "refresh")
+    end
+
+    assert_equal error.message, "Host is not a valid URI. Check your host option to make sure it is a properly formed url"
+  end
 end


### PR DESCRIPTION
This allows users to only have to worry about our gem's errors. This resolves #5.