### PR TITLE
feat: Add HTTP PUT support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+*  Add HTTP PUT support
+
+   *Matt Brinza*
+
 ## 0.6.8 (January 04, 2018)
 
 * Wrap `AccessTokenCredentials` external errors with our own errors

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ Stores automatically manage tokens for you - refreshing, revoking and storage
 are abstracted away to make your code as simple as possible. There are several
 different [types of stores](#stores) available to you.
 
-The Client class exposes `#get`, `#post`, `#patch` and `#delete` methods to you.
+The Client class exposes `#get`, `#post`, `#put`, `#patch` and `#delete` methods
+to you.
 
 ```ruby
 get(path, query = {})
 post(path, body = {}, options = {})
+put(path, body = {}, options = {})
 patch(path, body = {}, options = {})
 delete(path, query = {})
 ```

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -3,7 +3,7 @@ require "procore/requestable"
 module Procore
   # Main class end users interact with. An instance of a client can call out
   # the Procore API using methods matching standard HTTP verbs #get, #post,
-  # #patch, #delete.
+  # #put, #patch, #delete.
   #
   # @example Creating a new client:
   #   store = Procore::Auth::Stores::Session.new(session: session)

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -1,8 +1,8 @@
 require "httparty"
 
 module Procore
-  # Module which defines HTTP verbs GET, POST, PATCH and DELETE. Is included in
-  # Client. Has support for Idempotency Tokens on POST and PATCH.
+  # Module which defines HTTP verbs GET, POST, PUT, PATCH and DELETE. Is
+  # included in Client. Has support for Idempotency Tokens on POST and PATCH.
   #
   # @example Using #get:
   #   client.get("my_open_items", per_page: 5)
@@ -66,9 +66,37 @@ module Procore
     # @param path [String] URL path
     # @param body [Hash] Body parameters to send with the request
     # @param options [Hash} Extra request options
+    # TODO Add description for idempotency key
+    #
+    # @example Usage
+    #   client.put("dashboards/1/users", [1,2,3])
+    #
+    # @return [Response]
+    def put(path, body = {}, options = {})
+      Util.log_info(
+        "API Request Initiated",
+        path: "#{base_api_path}/#{path}",
+        method: "PUT",
+        body: body.to_s,
+      )
+
+      with_response_handling do
+        HTTParty.put(
+          "#{base_api_path}/#{path}",
+          body: body.to_json,
+          headers: headers(options),
+          timeout: Procore.configuration.timeout,
+        )
+      end
+    end
+
+    # @param path [String] URL path
+    # @param body [Hash] Body parameters to send with the request
+    # @param options [Hash} Extra request options
     # TODO Add description for idempotency token
     # @option options [String] :idempotency_token
     #
+    # @example Usage
     #   client.patch("users/1", { name: "Updated" }, { idempotency_token: "key" })
     #
     # @return [Response]

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -41,6 +41,21 @@ class Procore::RequestableTest < Minitest::Test
     Request.new(token: "token").post("home", name: "Name")
   end
 
+  def test_put
+    stub_request(:put, "http://test.com/home")
+      .with(
+        body: { name: "Replaced Name" },
+        headers: {
+          "Accepts" => "application/json",
+          "Authorization" => "Bearer token",
+          "Content-Type" => "application/json",
+        },
+      )
+      .to_return(status: 200, body: "", headers: {})
+
+    Request.new(token: "token").put("home", name: "Replaced Name")
+  end
+
   def test_patch
     stub_request(:patch, "http://test.com/home")
       .with(


### PR DESCRIPTION
This branch adds the `Client#put` method to support HTTP PUT requests.