### PR TITLE
feat: Add 400 response code as a bad request error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+*  Add 400 responses as Procore::InvalidRequestError
+
 ## 0.7.1 (February 22, 2018)
 
 *  Fix redis store guard clause

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -213,7 +213,7 @@ module Procore
           "exist.",
           response: response,
         )
-      when 422
+      when 400, 422
         raise Procore::InvalidRequestError.new(
           "Bad Request.",
           response: response,


### PR DESCRIPTION
This allows clients to debug and handle API responses that are caused
from malformed requests