### PR TITLE
fix: Redis guard clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+*  Fix redis store guard clause
+
+   *Patrick Koperwas*
+
 ## 0.7.0 (February 21, 2018)
 
 * Add multipart request support

--- a/lib/procore/auth/stores/redis.rb
+++ b/lib/procore/auth/stores/redis.rb
@@ -13,7 +13,7 @@ module Procore
         end
 
         def fetch
-          return if redis.get(redis_key).empty?
+          return unless redis.exists(redis_key)
 
           token = JSON.parse(redis.get(redis_key))
           Procore::Auth::Token.new(
@@ -24,7 +24,7 @@ module Procore
         end
 
         def delete
-          redis.set(redis_key, nil)
+          redis.del(redis_key)
         end
 
         def to_s


### PR DESCRIPTION
If a user deletes a token, then attempts to retreive that same token,
the SDK will raise an error because we are attempting to call #empty on
nil.

This changes the #get to an #exists check, and actually removes the key
from redis instead of setting it to nil.