### PR TITLE
feat: Save request body for debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 *  Add 400 responses as Procore::InvalidRequestError
+*  Add request_body to Procore::Response for debugging
 
 ## 0.7.1 (February 22, 2018)
 

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -53,7 +53,7 @@ module Procore
         body: body.to_s,
       )
 
-      with_response_handling do
+      with_response_handling(request_body: body) do
         RestClient::Request.execute(
           method: :post,
           url: "#{base_api_path}/#{path}",
@@ -81,7 +81,7 @@ module Procore
         body: body.to_s,
       )
 
-      with_response_handling do
+      with_response_handling(request_body: body) do
         RestClient::Request.execute(
           method: :put,
           url: "#{base_api_path}/#{path}",
@@ -110,7 +110,7 @@ module Procore
         body: body.to_s,
       )
 
-      with_response_handling do
+      with_response_handling(request_body: body) do
         RestClient::Request.execute(
           method: :patch,
           url: "#{base_api_path}/#{path}",
@@ -148,7 +148,7 @@ module Procore
 
     private
 
-    def with_response_handling
+    def with_response_handling(request_body: nil)
       request_start_time = Time.now
       retries = 0
 
@@ -176,6 +176,7 @@ module Procore
         headers: result.headers,
         code: result.code,
         request: result.request,
+        request_body: request_body,
       )
 
       case result.code
@@ -248,7 +249,11 @@ module Procore
     end
 
     def payload(body)
-      multipart?(body) ? body : body.to_json
+      if multipart?(body)
+        body
+      else
+        body.to_json
+      end
     end
 
     def multipart?(body)

--- a/lib/procore/response.rb
+++ b/lib/procore/response.rb
@@ -43,13 +43,14 @@ module Procore
     #   @return [Integer] Status Code returned from Procore API.
     # @!attribute [r] pagination
     #   @return [Hash<Symbol, String>] Pagination URLs
-    attr_reader :headers, :code, :pagination, :request
+    attr_reader :headers, :code, :pagination, :request, :request_body
 
-    def initialize(body:, headers:, code:, request:)
+    def initialize(body:, headers:, code:, request:, request_body:)
       @code = code
       @headers = headers
       @pagination = parse_pagination
       @request = request
+      @request_body = request_body
       @raw_body = !body.to_s.empty? ? body : "{}".to_json
     end
 

--- a/test/procore/response_test.rb
+++ b/test/procore/response_test.rb
@@ -7,6 +7,7 @@ class Procore::Response::BodyTest < Minitest::Test
       code: 200,
       headers: {},
       request: nil,
+      request_body: nil,
     )
 
     assert_equal({ "key" => "value" }, response.body)
@@ -20,6 +21,7 @@ class Procore::Response::BodyTest < Minitest::Test
       code: 200,
       headers: {},
       request: nil,
+      request_body: nil,
     )
 
     assert_equal(response_body, response.body)
@@ -36,6 +38,7 @@ class Procore::Response::BodyTest < Minitest::Test
       code: 200,
       headers: { "link" => links },
       request: nil,
+      request_body: nil,
     )
 
     assert_equal(
@@ -58,6 +61,7 @@ class Procore::Response::BodyTest < Minitest::Test
       code: 200,
       headers: { "link" => links },
       request: nil,
+      request_body: nil,
     )
 
     assert_equal(
@@ -77,8 +81,23 @@ class Procore::Response::BodyTest < Minitest::Test
         "link" => "",
       },
       request: nil,
+      request_body: nil,
     )
 
     assert_equal({}, response.pagination)
+  end
+
+  def test_request_body
+    request_body = { key: "value" }
+
+    response = Procore::Response.new(
+      body: nil,
+      code: 200,
+      headers: {},
+      request: nil,
+      request_body: request_body,
+    )
+
+    assert_equal(request_body, response.request_body)
   end
 end


### PR DESCRIPTION
After we moved to RestClient it became impossible to access the request
body after the request had been made. This feature allows us to maintain
the previous requirement for debugging.