### PR TITLE
Rescue Procore::OAuthError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 0.8.2 (May 3, 2018)
+
+* Rescue Procore::OAuthError
+
+    *Casey Ochs*
+
 ## 0.8.1 (April 13, 2018)
 
 * Fix rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## Unreleased
 
-## 0.8.2 (May 3, 2018)
-
 * Rescue Procore::OAuthError
+* Add Procore::MissingTokenError
 
     *Casey Ochs*
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ rescue Procore::OAuthError => e
   # Raised whenever there is a problem with OAuth. Possible causes: required
   # credentials are missing or an access token failed to refresh.
 
+rescue Procore::MissingTokenError => e
+  # Raised whenever an access token is nil or invalid.
+
 rescue Procore::AuthorizationError => e
   # Raised when the request is attempting to access a resource the token's
   # owner does not have access to.

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -52,7 +52,7 @@ module Procore
       token = store.fetch
 
       if token.nil? || token.invalid?
-        raise Procore::OAuthError.new(
+        raise Procore::MissingTokenError.new(
           "Unable to retreive an access token from the store. Double check "   \
           "your store configuration and make sure to correctly store a token " \
           "before attempting to make API requests",

--- a/lib/procore/errors.rb
+++ b/lib/procore/errors.rb
@@ -63,4 +63,7 @@ module Procore
 
   # Raised when a Procore endpoint returns a 500x resonse code.
   ServerError = Class.new(Error)
+
+  # Raised when a token is missing with refresh failure.
+  MissingTokenError = Class.new(Error)
 end

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -163,7 +163,7 @@ module Procore
 
       begin
         result = yield
-      rescue RestClient::Exceptions::Timeout, Errno::ECONNREFUSED => e
+      rescue RestClient::Exceptions::Timeout, Errno::ECONNREFUSED, Procore::OAuthError => e
         if retries <= Procore.configuration.max_retries
           retries += 1
           sleep 1.5**retries

--- a/test/procore/auth/client_credentials_test.rb
+++ b/test/procore/auth/client_credentials_test.rb
@@ -126,4 +126,25 @@ class Procore::Auth::ClientCredentialsTest < Minitest::Test
 
     assert_equal error.message, "Host is not a valid URI. Check your host option to make sure it is a properly formed url"
   end
+
+  def test_procore_oauth_error
+    stub_request(:post, "https://procore.example.com/oauth/token")
+      .with(
+        body: {
+          "client_id" => "id",
+          "client_secret" => "secret",
+          "grant_type" => "client_credentials",
+        },
+      )
+
+    token = Procore::Auth::ClientCredentials.new(
+      client_id: "id",
+      client_secret: "secret",
+      host: "https://procore.example.com",
+    )
+
+    assert_raises Procore::OAuthError do
+      token.refresh
+    end
+  end
 end

--- a/test/procore/client_test.rb
+++ b/test/procore/client_test.rb
@@ -71,7 +71,7 @@ class Procore::ClientTest < Minitest::Test
       store: store,
     )
 
-    assert_raises(Procore::OAuthError) do
+    assert_raises(Procore::APIConnectionError) do
       client.get("me")
     end
   end

--- a/test/procore/client_test.rb
+++ b/test/procore/client_test.rb
@@ -71,7 +71,7 @@ class Procore::ClientTest < Minitest::Test
       store: store,
     )
 
-    assert_raises(Procore::APIConnectionError) do
+    assert_raises(Procore::MissingTokenError) do
       client.get("me")
     end
   end


### PR DESCRIPTION
Rescue Procore::OauthError in requestable to help alleviate concurrency issue.

1. Several threads all attempt to refresh a token at once.
2. First one succeeds, and replaces the token in the store
3. Second thread attempts to refresh, errors and raises Procore::OAuth
4. Retries request, this time getting the new credentials set by the first thread.