### PR TITLE
use file join for uris to prevent double slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 0.8.2 (May 7, 2018)
+
+* Fix Requestable paths to prevent double slash in URI
+  
+    *Megan O'Neill*
+
 ## 0.8.1 (April 13, 2018)
 
 * Fix rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Unreleased
 
-## 0.8.2 (May 7, 2018)
-
 * Fix Requestable paths to prevent double slash in URI
   
     *Megan O'Neill*

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -19,7 +19,7 @@ module Procore
     #
     # @return [Response]
     def get(path, query: {}, options: {})
-      full_path = File.join(base_api_path, path).to_s
+      full_path = full_path(path)
 
       Util.log_info(
         "API Request Initiated",
@@ -52,7 +52,7 @@ module Procore
     #
     # @return [Response]
     def post(path, body: {}, options: {})
-      full_path = File.join(base_api_path, path).to_s
+      full_path = full_path(path)
 
       Util.log_info(
         "API Request Initiated",
@@ -82,7 +82,7 @@ module Procore
     #
     # @return [Response]
     def put(path, body: {}, options: {})
-      full_path = File.join(base_api_path, path).to_s
+      full_path = full_path(path)
 
       Util.log_info(
         "API Request Initiated",
@@ -116,7 +116,7 @@ module Procore
     #
     # @return [Response]
     def patch(path, body: {}, options: {})
-      full_path = File.join(base_api_path, path).to_s
+      full_path = full_path(path)
 
       Util.log_info(
         "API Request Initiated",
@@ -145,7 +145,7 @@ module Procore
     #
     # @return [Response]
     def delete(path, query: {}, options: {})
-      full_path = File.join(base_api_path, path).to_s
+      full_path = full_path(path)
 
       Util.log_info(
         "API Request Initiated",
@@ -286,6 +286,10 @@ module Procore
 
     def multipart?(body)
       RestClient::Payload::has_file?(body)
+    end
+
+    def full_path(path)
+      File.join(base_api_path, path).to_s
     end
   end
 end

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -19,9 +19,11 @@ module Procore
     #
     # @return [Response]
     def get(path, query: {}, options: {})
+      full_path = File.join(base_api_path, path).to_s
+
       Util.log_info(
         "API Request Initiated",
-        path: "#{base_api_path}/#{path}",
+        path: full_path,
         method: "GET",
         query: query.to_s,
       )
@@ -29,7 +31,7 @@ module Procore
       with_response_handling do
         RestClient::Request.execute(
           method: :get,
-          url: "#{base_api_path}/#{path}",
+          url: full_path,
           headers: headers(options).merge(params: query),
           timeout: Procore.configuration.timeout,
         )
@@ -50,9 +52,11 @@ module Procore
     #
     # @return [Response]
     def post(path, body: {}, options: {})
+      full_path = File.join(base_api_path, path).to_s
+
       Util.log_info(
         "API Request Initiated",
-        path: "#{base_api_path}/#{path}",
+        path: full_path,
         method: "POST",
         body: body.to_s,
       )
@@ -60,7 +64,7 @@ module Procore
       with_response_handling(request_body: body) do
         RestClient::Request.execute(
           method: :post,
-          url: "#{base_api_path}/#{path}",
+          url: full_path,
           payload: payload(body),
           headers: headers(options),
           timeout: Procore.configuration.timeout,
@@ -78,9 +82,11 @@ module Procore
     #
     # @return [Response]
     def put(path, body: {}, options: {})
+      full_path = File.join(base_api_path, path).to_s
+
       Util.log_info(
         "API Request Initiated",
-        path: "#{base_api_path}/#{path}",
+        path: full_path,
         method: "PUT",
         body: body.to_s,
       )
@@ -88,7 +94,7 @@ module Procore
       with_response_handling(request_body: body) do
         RestClient::Request.execute(
           method: :put,
-          url: "#{base_api_path}/#{path}",
+          url: full_path,
           payload: payload(body),
           headers: headers(options),
           timeout: Procore.configuration.timeout,
@@ -110,9 +116,11 @@ module Procore
     #
     # @return [Response]
     def patch(path, body: {}, options: {})
+      full_path = File.join(base_api_path, path).to_s
+
       Util.log_info(
         "API Request Initiated",
-        path: "#{base_api_path}/#{path}",
+        path: full_path,
         method: "PATCH",
         body: body.to_s,
       )
@@ -120,7 +128,7 @@ module Procore
       with_response_handling(request_body: body) do
         RestClient::Request.execute(
           method: :patch,
-          url: "#{base_api_path}/#{path}",
+          url: full_path,
           payload: payload(body),
           headers: headers(options),
           timeout: Procore.configuration.timeout,
@@ -137,9 +145,11 @@ module Procore
     #
     # @return [Response]
     def delete(path, query: {}, options: {})
+      full_path = File.join(base_api_path, path).to_s
+
       Util.log_info(
         "API Request Initiated",
-        path: "#{base_api_path}/#{path}",
+        path: full_path,
         method: "DELETE",
         headers: headers(options),
         query: query.to_s,
@@ -148,7 +158,7 @@ module Procore
       with_response_handling do
         RestClient::Request.execute(
           method: :delete,
-          url: "#{base_api_path}/#{path}",
+          url: full_path,
           headers: headers.merge(params: query),
           timeout: Procore.configuration.timeout,
         )

--- a/lib/procore/version.rb
+++ b/lib/procore/version.rb
@@ -1,3 +1,3 @@
 module Procore
-  VERSION = "0.8.1".freeze
+  VERSION = "0.8.2".freeze
 end

--- a/lib/procore/version.rb
+++ b/lib/procore/version.rb
@@ -1,3 +1,3 @@
 module Procore
-  VERSION = "0.8.2".freeze
+  VERSION = "0.8.1".freeze
 end


### PR DESCRIPTION
## Changes
- This prevents getting bugs from using `client.get("/example")` instead of `client.get("example")`
  - The former would have resulted in `http://example.com//example` throwing an error, while the later would have worked. Now both work, preventing a common bug. IAM just encountered this one.