### PR TITLE
fix: SQLite3 gem dependency issue

### DIFF
--- a/procore.gemspec
+++ b/procore.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "redis"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.4"
   spec.add_development_dependency "webmock"
 
   spec.add_dependency "activesupport", "> 2.4"


### PR DESCRIPTION
From Travis:

```
LoadError: Error loading the 'sqlite3' Active Record adapter. Missing a
gem it depends on? can't activate sqlite3 (~> 1.3.6), already activated
sqlite3-1.4.0. Make sure all dependencies are added to Gemfile.
```

To fix, locked SQLite3 to 1.3.x