### PR TITLE
fix: On Ruby 2.6 + Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 
 services:
   - redis-server

--- a/lib/procore/auth/client_credentials.rb
+++ b/lib/procore/auth/client_credentials.rb
@@ -29,7 +29,7 @@ module Procore
           raise OAuthError.new(e.description, response: e.response)
         rescue Faraday::ConnectionFailed => e
           raise APIConnectionError.new("Connection Error: #{e.message}")
-        rescue URI::BadURIError
+        rescue URI::BadURIError, URI::InvalidURIError
           raise OAuthError.new(
             "Host is not a valid URI. Check your host option to make sure it "   \
             "is a properly formed url",

--- a/procore.gemspec
+++ b/procore.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "redis"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.3.6"
   spec.add_development_dependency "webmock"
 
   spec.add_dependency "activesupport", "> 2.4"


### PR DESCRIPTION
Lock the SQLite version to 1.3.x, as Rails 5.2 has a lock on that particular
version. Added Ruby 2.6 to the travis testing matrix as well, and added
handling for another potential URI error.