### PR TITLE
remove vapid prefix for rest endpoint requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Unreleased
 
-## 0.8.7 (April 18, 2019)
-
 * Add api_version to allow calls to procore rest endpoints
 
   *Shane Means*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Add api_version to allow calls to procore rest endpoints
+
+  *Shane Means*
+
 ## 0.8.6 (May 10, 2018)
 
 * Dalli Store
@@ -7,7 +11,7 @@
   *Patrick Koperwas*
 
 * Fix Requestable paths to prevent double slash in URI
-  
+
     *Megan O'Neill*
 
 ## 0.8.5 (May 9, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.8.7 (April 18, 2019)
+
 * Add api_version to allow calls to procore rest endpoints
 
   *Shane Means*

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -41,7 +41,11 @@ module Procore
     private
 
     def base_api_path
-      "#{options[:host]}/vapid"
+      "#{options[:host]}/#{api_version}"
+    end
+
+    def api_version
+      options[:api_version] || 'vapid'
     end
 
     # @raise [OAuthError] if the store does not have a token stored in it prior

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -297,7 +297,11 @@ module Procore
     end
 
     def full_path(path)
-      File.join(base_api_path, path).to_s
+      File.join(rest_compatible_base_api_path(path), path).to_s
+    end
+
+    def rest_compatible_base_api_path(path)
+      path.starts_with?('rest/') || path.starts_with?('/rest/') ? base_api_path.remove('/vapid') : base_api_path
     end
   end
 end

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -204,6 +204,7 @@ module Procore
         code: result.code,
         request: result.request,
         request_body: request_body,
+        api_version: api_version
       )
 
       case result.code
@@ -297,11 +298,7 @@ module Procore
     end
 
     def full_path(path)
-      File.join(rest_compatible_base_api_path(path), path).to_s
-    end
-
-    def rest_compatible_base_api_path(path)
-      path.starts_with?('rest/') || path.starts_with?('/rest/') ? base_api_path.remove('/vapid') : base_api_path
+      File.join(base_api_path, path).to_s
     end
   end
 end

--- a/lib/procore/response.rb
+++ b/lib/procore/response.rb
@@ -45,15 +45,16 @@ module Procore
     #   @return [Integer] Status Code returned from Procore API.
     # @!attribute [r] pagination
     #   @return [Hash<Symbol, String>] Pagination URLs
-    attr_reader :headers, :code, :pagination, :request, :request_body
+    attr_reader :headers, :code, :pagination, :request, :request_body, :api_version
 
-    def initialize(body:, headers:, code:, request:, request_body:)
+    def initialize(body:, headers:, code:, request:, request_body:, api_version: 'vapid')
       @code = code
       @headers = headers
       @pagination = parse_pagination
       @request = request
       @request_body = request_body
       @raw_body = !body.to_s.empty? ? body : "{}".to_json
+      @api_version = api_version
     end
 
     # @return [Array<Hash>, Hash] Ruby representation of JSON response. Hashes are
@@ -72,7 +73,7 @@ module Procore
 
     def parse_pagination
       headers[:link].to_s.split(", ").map(&:strip).reduce({}) do |links, link|
-        url, name = link.match(/vapid\/(.*?)>; rel="(\w+)"/).captures
+        url, name = link.match(/#{api_version}\/(.*?)>; rel="(\w+)"/).captures
         links.merge!(name.to_sym => url)
       end
     end

--- a/lib/procore/response.rb
+++ b/lib/procore/response.rb
@@ -50,11 +50,11 @@ module Procore
     def initialize(body:, headers:, code:, request:, request_body:, api_version: 'vapid')
       @code = code
       @headers = headers
+      @api_version = api_version
       @pagination = parse_pagination
       @request = request
       @request_body = request_body
       @raw_body = !body.to_s.empty? ? body : "{}".to_json
-      @api_version = api_version
     end
 
     # @return [Array<Hash>, Hash] Ruby representation of JSON response. Hashes are

--- a/lib/procore/version.rb
+++ b/lib/procore/version.rb
@@ -1,3 +1,3 @@
 module Procore
-  VERSION = "0.8.7".freeze
+  VERSION = "0.8.6".freeze
 end

--- a/lib/procore/version.rb
+++ b/lib/procore/version.rb
@@ -1,3 +1,3 @@
 module Procore
-  VERSION = "0.8.6".freeze
+  VERSION = "0.8.7".freeze
 end

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -4,13 +4,14 @@ class Procore::RequestableTest < Minitest::Test
   class Request
     include Procore::Requestable
 
-    attr_reader :access_token
-    def initialize(token:)
+    attr_reader :access_token, :api_version
+    def initialize(token:, api_version: 'vapid')
       @access_token = token
+      @api_version = api_version
     end
 
     def base_api_path
-      "http://test.com/vapid"
+      "http://test.com/#{@api_version}"
     end
   end
 
@@ -43,7 +44,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").get("rest/home", query: { per_page: 5 })
+    Request.new(token: "token", api_version: 'rest').get("home", query: { per_page: 5 })
 
     assert_requested request
   end
@@ -77,7 +78,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").post("rest/home", body: { name: "Name" })
+    Request.new(token: "token", api_version: 'rest').post("home", body: { name: "Name" })
 
     assert_requested request
   end
@@ -99,7 +100,7 @@ class Procore::RequestableTest < Minitest::Test
     assert_requested request
   end
 
-  def test_put
+  def test_rest_put
     request = stub_request(:put, "http://test.com/rest/home")
       .with(
         body: { name: "Replaced Name" },
@@ -111,7 +112,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").put("rest/home", body: { name: "Replaced Name" })
+    Request.new(token: "token", api_version: 'rest').put("home", body: { name: "Replaced Name" })
 
     assert_requested request
   end

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -10,12 +10,12 @@ class Procore::RequestableTest < Minitest::Test
     end
 
     def base_api_path
-      "http://test.com"
+      "http://test.com/vapid"
     end
   end
 
   def test_get
-    request = stub_request(:get, "http://test.com/home")
+    request = stub_request(:get, "http://test.com/vapid/home")
       .with(
         query: { per_page: 5 },
         headers: {
@@ -31,8 +31,25 @@ class Procore::RequestableTest < Minitest::Test
     assert_requested request
   end
 
+  def test_rest_get
+    request = stub_request(:get, "http://test.com/rest/home")
+      .with(
+        query: { per_page: 5 },
+        headers: {
+          "Accepts" => "application/json",
+          "Authorization" => "Bearer token",
+          "Content-Type" => "application/json",
+        },
+      )
+      .to_return(status: 200, body: "", headers: {})
+
+    Request.new(token: "token").get("rest/home", query: { per_page: 5 })
+
+    assert_requested request
+  end
+
   def test_post
-    request = stub_request(:post, "http://test.com/home")
+    request = stub_request(:post, "http://test.com/vapid/home")
       .with(
         body: { name: "Name" },
         headers: {
@@ -48,8 +65,25 @@ class Procore::RequestableTest < Minitest::Test
     assert_requested request
   end
 
+  def test_rest_post
+    request = stub_request(:post, "http://test.com/rest/home")
+      .with(
+        body: { name: "Name" },
+        headers: {
+          "Accepts" => "application/json",
+          "Authorization" => "Bearer token",
+          "Content-Type" => "application/json",
+        },
+      )
+      .to_return(status: 200, body: "", headers: {})
+
+    Request.new(token: "token").post("rest/home", body: { name: "Name" })
+
+    assert_requested request
+  end
+
   def test_put
-    request = stub_request(:put, "http://test.com/home")
+    request = stub_request(:put, "http://test.com/vapid/home")
       .with(
         body: { name: "Replaced Name" },
         headers: {
@@ -65,8 +99,25 @@ class Procore::RequestableTest < Minitest::Test
     assert_requested request
   end
 
+  def test_put
+    request = stub_request(:put, "http://test.com/rest/home")
+      .with(
+        body: { name: "Replaced Name" },
+        headers: {
+          "Accepts" => "application/json",
+          "Authorization" => "Bearer token",
+          "Content-Type" => "application/json",
+        },
+      )
+      .to_return(status: 200, body: "", headers: {})
+
+    Request.new(token: "token").put("rest/home", body: { name: "Replaced Name" })
+
+    assert_requested request
+  end
+
   def test_patch
-    request = stub_request(:patch, "http://test.com/home")
+    request = stub_request(:patch, "http://test.com/vapid/home")
       .with(
         body: { name: "New Name" },
         headers: {
@@ -83,7 +134,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_delete
-    request = stub_request(:delete, "http://test.com/home")
+    request = stub_request(:delete, "http://test.com/vapid/home")
       .with(headers: {
               "Accepts" => "application/json",
               "Authorization" => "Bearer token",
@@ -97,7 +148,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_post_with_idempotency_token
-    request = stub_request(:post, "http://test.com/home")
+    request = stub_request(:post, "http://test.com/vapid/home")
       .with(
         headers: {
           "Accepts" => "application/json",
@@ -118,7 +169,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_get_with_company_id
-    request = stub_request(:get, "http://test.com/home")
+    request = stub_request(:get, "http://test.com/vapid/home")
       .with(
         headers: {
           "Accepts" => "application/json",
@@ -138,7 +189,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_post_with_company_id
-    request = stub_request(:post, "http://test.com/home")
+    request = stub_request(:post, "http://test.com/vapid/home")
       .with(
         body: { name: "Name" },
         headers: {
@@ -160,7 +211,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_post_with_multipart_body
-    request = stub_request(:post, "http://test.com/home")
+    request = stub_request(:post, "http://test.com/vapid/home")
       .with(
         headers: {
           "Accepts" => "application/json",
@@ -178,7 +229,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_unauthorized_error
-    stub_request(:get, "http://test.com")
+    stub_request(:get, "http://test.com/vapid/")
       .to_return(status: 401, body: "", headers: {})
 
     assert_raises Procore::AuthorizationError do
@@ -187,7 +238,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_forbidden_error
-    stub_request(:get, "http://test.com")
+    stub_request(:get, "http://test.com/vapid/")
       .to_return(status: 403, body: "", headers: {})
 
     assert_raises Procore::ForbiddenError do
@@ -196,7 +247,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_not_found_error
-    stub_request(:get, "http://test.com")
+    stub_request(:get, "http://test.com/vapid/")
       .to_return(status: 404, body: "", headers: {})
 
     assert_raises Procore::NotFoundError do
@@ -205,7 +256,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_server_error
-    stub_request(:get, "http://test.com")
+    stub_request(:get, "http://test.com/vapid/")
       .to_return(status: 500, body: "", headers: {})
 
     assert_raises Procore::ServerError do
@@ -214,7 +265,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_error_body
-    stub_request(:get, "http://test.com")
+    stub_request(:get, "http://test.com/vapid/")
       .to_return(
         status: 401,
         body: { errors: "Unauthorized" }.to_json,


### PR DESCRIPTION
As we move to our 'rest' endpoints, we need to remove the vapid prefix for requests.

This is backwards compatible with what the client was doing. It now supports 'rest' api calls as well now.