### PR TITLE
feat: Expose #sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Expose #sync, a method that enables calling sync-actions
+
+  *Patrick Koperwas*
+
 * Addition of contribution guidelines to README
 
   *Megan O'Neill*

--- a/lib/procore/configuration.rb
+++ b/lib/procore/configuration.rb
@@ -77,7 +77,20 @@ module Procore
     # @return [String]
     attr_accessor :user_agent
 
+    # @!attribute [rw] default_batch_size
+    # @note defaults to Defaults::BATCH_SIZE
+    #
+    # When using #sync action, sets the default batch size to use for chunking
+    # up a request body. Example, if the size is set to 500 and 2,000 updates
+    # are desired, 4 requests will be made.
+    #
+    # Note: The maximum size is 1,000
+    #
+    # @return [Integer]
+    attr_accessor :default_batch_size
+
     def initialize
+      @default_batch_size = Procore::Defaults::BATCH_SIZE
       @host = Procore::Defaults::API_ENDPOINT
       @logger = nil
       @max_retries = 1

--- a/lib/procore/defaults.rb
+++ b/lib/procore/defaults.rb
@@ -9,6 +9,9 @@ module Procore
     # Default User Agent header string
     USER_AGENT = "Procore Ruby Gem #{Procore::VERSION}".freeze
 
+    # Default size to use for batch requests
+    BATCH_SIZE = 500
+
     def self.client_options
       {
         host: Procore.configuration.host,

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -48,7 +48,7 @@ module Procore
 
     # @param path [String] URL path
     # @param body [Hash] Body parameters to send with the request
-    # @param options [Hash} Extra request options
+    # @param options [Hash] Extra request options
     # @option options [String] :idempotency_token | :company_id
     #
     # @example Usage
@@ -82,7 +82,7 @@ module Procore
 
     # @param path [String] URL path
     # @param body [Hash] Body parameters to send with the request
-    # @param options [Hash} Extra request options
+    # @param options [Hash] Extra request options
     # @option options [String] :idempotency_token | :company_id
     #
     # @example Usage
@@ -112,7 +112,7 @@ module Procore
 
     # @param path [String] URL path
     # @param body [Hash] Body parameters to send with the request
-    # @param options [Hash} Extra request options
+    # @param options [Hash] Extra request options
     # @option options [String] :idempotency_token | :company_id
     #
     # @example Usage
@@ -146,7 +146,7 @@ module Procore
 
     # @param path [String] URL path
     # @param body [Hash] Body parameters to send with the request
-    # @param options [Hash} Extra request options
+    # @param options [Hash] Extra request options
     # @option options [String | Integer] :company_id | :batch_size
     #
     # @example Usage

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -145,6 +145,72 @@ module Procore
     end
 
     # @param path [String] URL path
+    # @param body [Hash] Body parameters to send with the request
+    # @param options [Hash} Extra request options
+    # @option options [String | Integer] :company_id | :batch_size
+    #
+    # @example Usage
+    #   client.sync(
+    #     "projects/sync",
+    #     body: {
+    #       updates: [
+    #        { id: 1, name: "Update 1" },
+    #        { id: 2, name: "Update 2" },
+    #        { id: 3, name: "Update 3" },
+    #        ...
+    #        ...
+    #        { id: 5055, name: "Update 5055" },
+    #       ]
+    #     },
+    #     options: { batch_size: 500, company_id: 1 },
+    #   )
+    #
+    # @return [Response]
+    def sync(path, body: {}, options: {})
+      full_path = full_path(path)
+
+      batch_size = options[:batch_size] ||
+        Procore.configuration.default_batch_size
+
+      if batch_size > 1000
+        batch_size = 1000
+      end
+
+      Util.log_info(
+        "API Request Initiated",
+        path: full_path,
+        method: "SYNC",
+        batch_size: batch_size,
+      )
+
+      groups = body[:updates].in_groups_of(batch_size, false)
+
+      responses = groups.map do |group|
+        batched_body = body.merge(updates: group)
+        with_response_handling(request_body: batched_body) do
+          RestClient::Request.execute(
+            method: :patch,
+            url: full_path,
+            payload: payload(batched_body),
+            headers: headers(options),
+            timeout: Procore.configuration.timeout,
+          )
+        end
+      end
+
+      Procore::Response.new(
+        body: responses.reduce({}) do |combined, response|
+          combined.deep_merge(response.body) { |_, v1, v2| v1 + v2 }
+        end.to_json,
+        headers: responses.map(&:headers).inject({}, &:deep_merge),
+        code: 200,
+        request: responses.last&.request,
+        request_body: body,
+        api_version: api_version,
+      )
+    end
+
+    # @param path [String] URL path
     # @param query [Hash] Query options to pass along with the request
     # @option options [String] :company_id
     #


### PR DESCRIPTION
Sync actions enable batch creation or updates for certain supported
resources in the Procore API.

See https://developers.procore.com/documentation/using-sync-actions
for documentation on how to use sync actions.

Related to #33.

---

@phuminhphan apologies, my thoughts didn't come across clearly in #33. What I was getting at is that `sync` is definitely a primitive worth exposing, it just needs to behave like the other methods on [Client do](https://github.com/procore/ruby-sdk#making-requests). 

```ruby
client.sync(
 "projects/sync",
 body: {
   updates: [
    { id: 1, name: "Update 1" },
    { id: 2, name: "Update 2" },
    { id: 3, name: "Update 3" },
    ...
    ...
    { id: 5055, name: "Update 5055" },
   ]
 },
 options: { batch_size: 500, company_id: 1 },
)
```

By being implemented in`requestable`, the correct API Errors will be raised  if the access token lacks permissions, or is expired, or if Procore is currently unavailable, or the rate limit has been exceeded, etc. 

A [`Procore::Response`](https://www.rubydoc.info/gems/procore/0.8.5/Procore/Response) gets returned to the end user, which is consistent with `get`, `put`, etc., and provides a rich abstraction over a Procore API response.

