### PR TITLE
[ZL-751] Support Rest API migration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
+require: 
+  - rubocop-rails
+  - rubocop-performance
+
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Include:
     - '**/Rakefile'
     - '**/config.ru'
@@ -305,7 +309,7 @@ Style/PerlBackrefs:
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark'
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
   Exclude:
     - spec/**/*
@@ -437,7 +441,7 @@ Style/RedundantBegin:
 
 # Layout
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Description: 'Here we check if the parameters on a multi-line method call or definition are aligned.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
   Enabled: false
@@ -505,7 +509,7 @@ Lint/DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'
   Enabled: false
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Description: 'Check for duplicate keys in hash literals.'
   Enabled: false
 
@@ -521,7 +525,7 @@ Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: false
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: "Don't suppress exception."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Changes how API versions are handled. Switches default version from Vapid to Rest v1.0.
+* Changes how API versioning is handled, and requires configuring a default version.
 
   *Nate Baer*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Changes how API versions are handled. Switches default version from Vapid to Rest v1.0.
+
+  *Nate Baer*
+
 ## 0.8.8 (October 17, 2019)
 
 * Expose #sync, a method that enables calling sync-actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Changes how API versioning is handled, and requires configuring a default version.
+* Adds support for API versioning
 
   *Nate Baer*
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,13 @@ delete(path, query: {})
 sync(path, body: {}, options: {})
 ```
 
-All paths are relative - the gem will handle expanding `client.get("me")` to
-`https://app.procore.com/vapid/me`.
+All paths are relative, the gem will handle expanding them. An API version may be specified in the path, or the latest major version of Rest is used by default (currently v1.0).
+
+| Example | Requested URL |
+| --- | --- |
+| `client.get("me")` | `https://app.procore.com/rest/v1.0/me` |
+| `client.get("rest/v1.1/me")` | `https://app.procore.com/rest/v1.1/me` |
+| `client.get("vapid/me")` | `https://app.procore.com/vapid/me` |
 
 Example Usage:
 

--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@ Stores automatically manage tokens for you - refreshing, revoking and storage
 are abstracted away to make your code as simple as possible. There are several
 different [types of stores](#stores) available to you.
 
-The Client class exposes `#get`, `#post`, `#put`, `#patch`, '#sync' and
+The Client class exposes `#get`, `#post`, `#put`, `#patch`, `#sync` and
 `#delete` methods to you.
 
 ```ruby
-get(path, query: {})
-post(path, body: {}, options: {})
-put(path, body: {}, options: {})
-patch(path, body: {}, options: {})
-delete(path, query: {})
-sync(path, body: {}, options: {})
+   get(path, version: "", query: {})
+  post(path, version: "", body: {}, options: {})
+   put(path, version: "", body: {}, options: {})
+ patch(path, version: "", body: {}, options: {})
+delete(path, version: "", query: {})
+  sync(path, version: "", body: {}, options: {})
 ```
 
 All paths are relative, the gem will handle expanding them. An API version may
@@ -70,7 +70,10 @@ store = Procore::Auth::Stores::Session.new(session: session)
 client = Procore::Client.new(
   client_id: "client id",
   client_secret: "client secret",
-  store: store
+  store: store,
+  options {
+    default_version: "v1.0",
+  }
 )
 
 # Get the current user's companies

--- a/README.md
+++ b/README.md
@@ -329,6 +329,10 @@ Procore.configure do |config|
   # are desired, 4 requests will be made. Note, the maximum size is 1000.
   config.default_batch_size = 500
 
+  # The default API version to use if none is specified in the request.
+  # Should be either "v1.0" (recommended) or "vapid" (legacy).
+  config.default_version = "v1.0"
+
   # Integer: Number of times to retry a failed API call. Reasons an API call
   # could potentially fail:
   # 1. Service is briefly down or unreachable

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ companies.first[:name] #=> "Procore Company 1"
 To use Procore's older API Vapid by default, the default version can be set in
 either the Gem's [configuration](https://github.com/procore/ruby-sdk#configuration)
 or the client's `options` hash:
+
 ```ruby
 client = Procore::Client.new(
   ...
@@ -90,7 +91,6 @@ client = Procore::Client.new(
   }
 )
 ```
-
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ store = Procore::Auth::Stores::Session.new(session: session)
 client = Procore::Client.new(
   client_id: "client id",
   client_secret: "client secret",
-  store: store,
+  store: store
 )
 
 # Get the current user's companies
@@ -87,7 +87,7 @@ or the client's `options` hash:
 client = Procore::Client.new(
   ...
   options {
-    default_version: "vapid",
+    default_version: "vapid"
   }
 )
 ```

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ delete(path, version: "", query: {})
 ```
 
 All paths are relative, the gem will handle expanding them. An API version may
-be specified in the `version:` argument, or the default version from the
-configuration is used.
+be specified in the `version:` argument, or the default version is used. The
+default version is `v1.0` unless otherwise configured.
 
 | Example | Requested URL |
 | --- | --- |
@@ -71,9 +71,6 @@ client = Procore::Client.new(
   client_id: "client id",
   client_secret: "client secret",
   store: store,
-  options {
-    default_version: "v1.0",
-  }
 )
 
 # Get the current user's companies
@@ -81,6 +78,19 @@ companies = client.get("companies")
 
 companies.first[:name] #=> "Procore Company 1"
 ```
+
+To use Procore's older API Vapid by default, the default version can be set in
+either the Gem's [configuration](https://github.com/procore/ruby-sdk#configuration)
+or the client's `options` hash:
+```ruby
+client = Procore::Client.new(
+  ...
+  options {
+    default_version: "vapid",
+  }
+)
+```
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ delete(path, query: {})
 sync(path, body: {}, options: {})
 ```
 
-All paths are relative, the gem will handle expanding them. An API version may be specified in the path, or the latest major version of Rest is used by default (currently v1.0).
+All paths are relative, the gem will handle expanding them. An API version may
+be specified in the `version:` argument, or the default version from the
+configuration is used.
 
 | Example | Requested URL |
 | --- | --- |
 | `client.get("me")` | `https://app.procore.com/rest/v1.0/me` |
-| `client.get("rest/v1.1/me")` | `https://app.procore.com/rest/v1.1/me` |
-| `client.get("vapid/me")` | `https://app.procore.com/vapid/me` |
+| `client.get("me", version: "v1.1")` | `https://app.procore.com/rest/v1.1/me` |
+| `client.get("me", version: "vapid")` | `https://app.procore.com/vapid/me` |
 
 Example Usage:
 

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -45,7 +45,7 @@ module Procore
     end
 
     def base_api_default_path
-      "#{options[:host]}/vapid"
+      "#{options[:host]}/rest/v1.0"
     end
 
     # @raise [OAuthError] if the store does not have a token stored in it prior

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -44,10 +44,6 @@ module Procore
       "#{options[:host]}"
     end
 
-    def base_api_default_path
-      "#{options[:host]}/rest/v1.0"
-    end
-
     # @raise [OAuthError] if the store does not have a token stored in it prior
     #   to making a request.
     # @raise [OAuthError] if a token cannot be refreshed.

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -41,11 +41,11 @@ module Procore
     private
 
     def base_api_path
-      "#{options[:host]}/#{api_version}"
+      "#{options[:host]}"
     end
 
-    def api_version
-      options[:api_version] || 'vapid'
+    def base_api_default_path
+      "#{options[:host]}/vapid"
     end
 
     # @raise [OAuthError] if the store does not have a token stored in it prior

--- a/lib/procore/configuration.rb
+++ b/lib/procore/configuration.rb
@@ -32,6 +32,15 @@ module Procore
     # @return [String]
     attr_accessor :host
 
+    # @!attribute [rw] default_version
+    # @note defaults to Defaults::API_ENDPOINT
+    #
+    # The default API version to use if none is specified in the request.
+    # Should be either "v1.0" (recommended) or "vapid" (legacy).
+    #
+    # @return [String]
+    attr_accessor :default_version
+
     # @!attribute [rw] logger
     # @note defaults to nil
     #

--- a/lib/procore/configuration.rb
+++ b/lib/procore/configuration.rb
@@ -11,10 +11,6 @@ module Procore
   #   end
   def self.configure
     yield(configuration)
-    
-    if configuration.default_version.nil?
-      raise ArgumentError.new "default_version must be configured for the Procore API"
-    end
   end
 
   # The current configuration for the gem.
@@ -37,7 +33,7 @@ module Procore
     attr_accessor :host
 
     # @!attribute [rw] default_version
-    # @note required attribute
+    # @note defaults to Defaults::DEFAULT_VERSION
     #
     # The default API version to use if none is specified in the request.
     # Should be either "v1.0" (recommended) or "vapid" (legacy).
@@ -109,6 +105,7 @@ module Procore
       @max_retries = 1
       @timeout = 1.0
       @user_agent = Procore::Defaults::USER_AGENT
+      @default_version = Procore::Defaults::DEFAULT_VERSION
     end
   end
 end

--- a/lib/procore/configuration.rb
+++ b/lib/procore/configuration.rb
@@ -11,6 +11,10 @@ module Procore
   #   end
   def self.configure
     yield(configuration)
+    
+    if configuration.default_version.nil?
+      raise ArgumentError.new "default_version must be configured for the Procore API"
+    end
   end
 
   # The current configuration for the gem.

--- a/lib/procore/configuration.rb
+++ b/lib/procore/configuration.rb
@@ -37,7 +37,7 @@ module Procore
     attr_accessor :host
 
     # @!attribute [rw] default_version
-    # @note defaults to Defaults::API_ENDPOINT
+    # @note required attribute
     #
     # The default API version to use if none is specified in the request.
     # Should be either "v1.0" (recommended) or "vapid" (legacy).

--- a/lib/procore/defaults.rb
+++ b/lib/procore/defaults.rb
@@ -12,6 +12,9 @@ module Procore
     # Default size to use for batch requests
     BATCH_SIZE = 500
 
+    # Default API version to use
+    DEFAULT_VERSION = "v1.0"
+
     def self.client_options
       {
         host: Procore.configuration.host,

--- a/lib/procore/defaults.rb
+++ b/lib/procore/defaults.rb
@@ -16,6 +16,7 @@ module Procore
       {
         host: Procore.configuration.host,
         user_agent: Procore.configuration.user_agent,
+        default_version: Procore.configuration.default_version,
       }
     end
   end

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -26,8 +26,8 @@ module Procore
     #   client.get("my_open_items", query: { per_page: 5, filter: {} })
     #
     # @return [Response]
-    def get(path, query: {}, options: {})
-      full_path = full_path(path)
+    def get(path, version: nil, query: {}, options: {})
+      full_path = full_path(path, version)
 
       Util.log_info(
         "API Request Initiated",
@@ -59,8 +59,8 @@ module Procore
     #   )
     #
     # @return [Response]
-    def post(path, body: {}, options: {})
-      full_path = full_path(path)
+    def post(path, version: nil, body: {}, options: {})
+      full_path = full_path(path, version)
 
       Util.log_info(
         "API Request Initiated",
@@ -89,8 +89,8 @@ module Procore
     #   client.put("dashboards/1/users", body: [1,2,3], options: { company_id: 1 })
     #
     # @return [Response]
-    def put(path, body: {}, options: {})
-      full_path = full_path(path)
+    def put(path, version: nil, body: {}, options: {})
+      full_path = full_path(path, version)
 
       Util.log_info(
         "API Request Initiated",
@@ -123,8 +123,8 @@ module Procore
     #   )
     #
     # @return [Response]
-    def patch(path, body: {}, options: {})
-      full_path = full_path(path)
+    def patch(path, version: nil, body: {}, options: {})
+      full_path = full_path(path, version)
 
       Util.log_info(
         "API Request Initiated",
@@ -166,8 +166,8 @@ module Procore
     #   )
     #
     # @return [Response]
-    def sync(path, body: {}, options: {})
-      full_path = full_path(path)
+    def sync(path, version: nil, body: {}, options: {})
+      full_path = full_path(path, version)
 
       batch_size = options[:batch_size] ||
         Procore.configuration.default_batch_size
@@ -217,8 +217,8 @@ module Procore
     #   client.delete("users/1", query: {}, options: {})
     #
     # @return [Response]
-    def delete(path, query: {}, options: {})
-      full_path = full_path(path)
+    def delete(path, version: nil, query: {}, options: {})
+      full_path = full_path(path, version)
 
       Util.log_info(
         "API Request Initiated",
@@ -361,12 +361,15 @@ module Procore
       RestClient::Payload::has_file?(body)
     end
 
-    def full_path(path)
-      if /(vapid|rest)/ =~ path
-        File.join(base_api_path, path)
+    def full_path(path, version)
+      version ||= options[:default_version]
+      if version == "vapid"
+        File.join(base_api_path, "/vapid", path)
+      elsif /^v\d+\.\d+$/.match?(version)
+        File.join(base_api_path, "/rest/#{version}", path)
       else
-        File.join(base_api_default_path, path)
-      end.to_s
+        raise ArgumentError.new "'#{version}' is an invalid Procore API version"
+      end
     end
   end
 end

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -362,7 +362,6 @@ module Procore
     end
 
     def full_path(path)
-      # require 'pry'; binding.pry
       if path.match?(/(vapid|rest)/)
         File.join(base_api_path, path)
       else

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -364,9 +364,9 @@ module Procore
     def full_path(path, version)
       version ||= options[:default_version]
       if version == "vapid"
-        File.join(base_api_path, "/vapid", path)
+        File.join(base_api_path, "vapid", path)
       elsif /\Av\d+\.\d+\z/.match?(version)
-        File.join(base_api_path, "/rest/#{version}", path)
+        File.join(base_api_path, "rest", version, path)
       else
         raise ArgumentError.new "'#{version}' is an invalid Procore API version"
       end

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -362,7 +362,7 @@ module Procore
     end
 
     def full_path(path)
-      if path.match?(/(vapid|rest)/)
+      if /(vapid|rest)/ =~ path
         File.join(base_api_path, path)
       else
         File.join(base_api_default_path, path)

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -19,6 +19,7 @@ module Procore
       RestClient::ServerBrokeConnection,
     ].freeze
     # @param path [String] URL path
+    # @param version [String] API version
     # @param query [Hash] Query options to pass along with the request
     # @option options [Hash] :company_id
     #
@@ -47,6 +48,7 @@ module Procore
     end
 
     # @param path [String] URL path
+    # @param version [String] API version
     # @param body [Hash] Body parameters to send with the request
     # @param options [Hash] Extra request options
     # @option options [String] :idempotency_token | :company_id
@@ -81,6 +83,7 @@ module Procore
     end
 
     # @param path [String] URL path
+    # @param version [String] API version
     # @param body [Hash] Body parameters to send with the request
     # @param options [Hash] Extra request options
     # @option options [String] :idempotency_token | :company_id
@@ -111,6 +114,7 @@ module Procore
     end
 
     # @param path [String] URL path
+    # @param version [String] API version
     # @param body [Hash] Body parameters to send with the request
     # @param options [Hash] Extra request options
     # @option options [String] :idempotency_token | :company_id
@@ -145,6 +149,7 @@ module Procore
     end
 
     # @param path [String] URL path
+    # @param version [String] API version
     # @param body [Hash] Body parameters to send with the request
     # @param options [Hash] Extra request options
     # @option options [String | Integer] :company_id | :batch_size
@@ -210,6 +215,7 @@ module Procore
     end
 
     # @param path [String] URL path
+    # @param version [String] API version
     # @param query [Hash] Query options to pass along with the request
     # @option options [String] :company_id
     #

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -206,7 +206,6 @@ module Procore
         code: 200,
         request: responses.last&.request,
         request_body: body,
-        api_version: api_version,
       )
     end
 
@@ -270,7 +269,6 @@ module Procore
         code: result.code,
         request: result.request,
         request_body: request_body,
-        api_version: api_version
       )
 
       case result.code
@@ -364,7 +362,12 @@ module Procore
     end
 
     def full_path(path)
-      File.join(base_api_path, path).to_s
+      # require 'pry'; binding.pry
+      if path.match?(/(vapid|rest)/)
+        File.join(base_api_path, path)
+      else
+        File.join(base_api_default_path, path)
+      end.to_s
     end
   end
 end

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -373,8 +373,10 @@ module Procore
         File.join(base_api_path, "vapid", path)
       elsif /\Av\d+\.\d+\z/.match?(version)
         File.join(base_api_path, "rest", version, path)
-      else
+      elsif version.present?
         raise ArgumentError.new "'#{version}' is an invalid Procore API version"
+      else
+        raise ArgumentError.new "A Procore API version was not specified"
       end
     end
   end

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -373,10 +373,8 @@ module Procore
         File.join(base_api_path, "vapid", path)
       elsif /\Av\d+\.\d+\z/.match?(version)
         File.join(base_api_path, "rest", version, path)
-      elsif version.present?
-        raise ArgumentError.new "'#{version}' is an invalid Procore API version"
       else
-        raise ArgumentError.new "A Procore API version was not specified"
+        raise ArgumentError.new "'#{version}' is an invalid Procore API version"
       end
     end
   end

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -188,7 +188,7 @@ module Procore
         batch_size: batch_size,
       )
 
-      groups = body[:updates].in_groups_of(batch_size, false)
+      groups = body[:updates].each_slice(batch_size).to_a
 
       responses = groups.map do |group|
         batched_body = body.merge(updates: group)

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -365,7 +365,7 @@ module Procore
       version ||= options[:default_version]
       if version == "vapid"
         File.join(base_api_path, "/vapid", path)
-      elsif /^v\d+\.\d+$/.match?(version)
+      elsif /\Av\d+\.\d+\z/.match?(version)
         File.join(base_api_path, "/rest/#{version}", path)
       else
         raise ArgumentError.new "'#{version}' is an invalid Procore API version"

--- a/lib/procore/response.rb
+++ b/lib/procore/response.rb
@@ -45,12 +45,11 @@ module Procore
     #   @return [Integer] Status Code returned from Procore API.
     # @!attribute [r] pagination
     #   @return [Hash<Symbol, String>] Pagination URLs
-    attr_reader :headers, :code, :pagination, :request, :request_body, :api_version
+    attr_reader :headers, :code, :pagination, :request, :request_body
 
-    def initialize(body:, headers:, code:, request:, request_body:, api_version: 'vapid')
+    def initialize(body:, headers:, code:, request:, request_body:)
       @code = code
       @headers = headers
-      @api_version = api_version
       @pagination = parse_pagination
       @request = request
       @request_body = request_body
@@ -73,7 +72,7 @@ module Procore
 
     def parse_pagination
       headers[:link].to_s.split(", ").map(&:strip).reduce({}) do |links, link|
-        url, name = link.match(/#{api_version}\/(.*?)>; rel="(\w+)"/).captures
+        url, name = link.match(/(?:vapid|rest\/.*?)\/(.*?)>; rel="(\w+)"/).captures
         links.merge!(name.to_sym => url)
       end
     end

--- a/procore.gemspec
+++ b/procore.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "redis"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "rubocop-rails"
   spec.add_development_dependency "rubocop-performance"
+  spec.add_development_dependency "rubocop-rails"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "webmock"
 

--- a/procore.gemspec
+++ b/procore.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "redis"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop-rails"
+  spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "webmock"
 

--- a/test/procore/client_test.rb
+++ b/test/procore/client_test.rb
@@ -38,7 +38,7 @@ class Procore::ClientTest < Minitest::Test
 
   def test_client_active_recored_expired_token
     stub_refresh_token
-    stub_request(:get, "https://procore.example.com/vapid/me")
+    stub_request(:get, "https://procore.example.com/rest/v1.0/me")
 
     user = User.create(
       access_token: "token",

--- a/test/procore/client_test.rb
+++ b/test/procore/client_test.rb
@@ -28,6 +28,7 @@ class Procore::ClientTest < Minitest::Test
       store: store,
       options: {
         host: "https://example.com",
+        default_version: "v1.0",
         user_agent: "Procore Test Suite",
       },
     )
@@ -51,6 +52,9 @@ class Procore::ClientTest < Minitest::Test
       client_id: "client_id",
       client_secret: "client secret",
       store: store,
+      options: {
+        default_version: "v1.0",
+      },
     )
 
     client.get("me")
@@ -69,6 +73,9 @@ class Procore::ClientTest < Minitest::Test
       client_id: "client_id",
       client_secret: "client secret",
       store: store,
+      options: {
+        default_version: "v1.0",
+      },
     )
 
     assert_raises(Procore::MissingTokenError) do

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -10,7 +10,7 @@ class Procore::RequestableTest < Minitest::Test
       @api_version = api_version
     end
 
-    def base_api_path
+    def base_api_default_path
       "http://test.com/#{@api_version}"
     end
   end

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -5,6 +5,7 @@ class Procore::RequestableTest < Minitest::Test
     include Procore::Requestable
 
     attr_reader :access_token
+
     def initialize(token:)
       @access_token = token
     end
@@ -13,8 +14,10 @@ class Procore::RequestableTest < Minitest::Test
       "http://test.com"
     end
 
-    def base_api_default_path
-      "#{base_api_path}/rest/v1.0"
+    def options
+      {
+        default_version: "v1.0",
+      }
     end
   end
 
@@ -47,7 +50,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").get("rest/v1.1/home", query: { per_page: 5 })
+    Request.new(token: "token").get("home", version: "v1.1", query: { per_page: 5 })
 
     assert_requested request
   end
@@ -60,7 +63,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").get("vapid/home", query: { per_page: 5 })
+    Request.new(token: "token").get("home", version: "vapid", query: { per_page: 5 })
 
     assert_requested request
   end
@@ -86,7 +89,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").post("rest/v1.1/home", body: { name: "Name" })
+    Request.new(token: "token").post("home", version: "v1.1", body: { name: "Name" })
 
     assert_requested request
   end
@@ -99,7 +102,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").post("vapid/home", body: { name: "Name" })
+    Request.new(token: "token").post("home", version: "vapid", body: { name: "Name" })
 
     assert_requested request
   end
@@ -125,7 +128,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").put("rest/v1.1/home", body: { name: "Replaced Name" })
+    Request.new(token: "token").put("home", version: "v1.1", body: { name: "Replaced Name" })
 
     assert_requested request
   end
@@ -139,7 +142,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").put("vapid/home", body: { name: "Replaced Name" })
+    Request.new(token: "token").put("home", version: "vapid", body: { name: "Replaced Name" })
 
     assert_requested request
   end

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -18,15 +18,19 @@ class Procore::RequestableTest < Minitest::Test
     end
   end
 
+  def headers
+    {
+      "Accepts" => "application/json",
+      "Authorization" => "Bearer token",
+      "Content-Type" => "application/json",
+    }
+  end
+
   def test_get
     request = stub_request(:get, "http://test.com/rest/v1.0/home")
       .with(
         query: { per_page: 5 },
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => "application/json",
-        },
+        headers: headers
       )
       .to_return(status: 200, body: "", headers: {})
 
@@ -39,11 +43,7 @@ class Procore::RequestableTest < Minitest::Test
     request = stub_request(:get, "http://test.com/vapid/home")
       .with(
         query: { per_page: 5 },
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => "application/json",
-        },
+        headers: headers
       )
       .to_return(status: 200, body: "", headers: {})
 
@@ -73,11 +73,7 @@ class Procore::RequestableTest < Minitest::Test
     request = stub_request(:post, "http://test.com/vapid/home")
       .with(
         body: { name: "Name" },
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => "application/json",
-        },
+        headers: headers
       )
       .to_return(status: 200, body: "", headers: {})
 
@@ -90,11 +86,7 @@ class Procore::RequestableTest < Minitest::Test
     request = stub_request(:put, "http://test.com/rest/v1.0/home")
       .with(
         body: { name: "Replaced Name" },
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => "application/json",
-        },
+        headers: headers
       )
       .to_return(status: 200, body: "", headers: {})
 
@@ -107,11 +99,7 @@ class Procore::RequestableTest < Minitest::Test
     request = stub_request(:put, "http://test.com/vapid/home")
       .with(
         body: { name: "Replaced Name" },
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => "application/json",
-        },
+        headers: headers
       )
       .to_return(status: 200, body: "", headers: {})
 
@@ -124,11 +112,7 @@ class Procore::RequestableTest < Minitest::Test
     request = stub_request(:patch, "http://test.com/rest/v1.0/home")
       .with(
         body: { name: "New Name" },
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => "application/json",
-        },
+        headers: headers
       )
       .to_return(status: 200, body: "", headers: {})
 
@@ -139,11 +123,7 @@ class Procore::RequestableTest < Minitest::Test
 
   def test_delete
     request = stub_request(:delete, "http://test.com/rest/v1.0/home")
-      .with(headers: {
-              "Accepts" => "application/json",
-              "Authorization" => "Bearer token",
-              "Content-Type" => "application/json",
-            })
+      .with(headers: headers)
       .to_return(status: 200, body: "", headers: {})
 
     Request.new(token: "token").delete("home")
@@ -202,12 +182,7 @@ class Procore::RequestableTest < Minitest::Test
   def test_post_with_idempotency_token
     request = stub_request(:post, "http://test.com/rest/v1.0/home")
       .with(
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => "application/json",
-          "Idempotency-Token" => "token",
-        },
+        headers: headers.merge("Idempotency-Token" => "token"),
       )
       .to_return(status: 200, body: "", headers: {})
 
@@ -223,12 +198,7 @@ class Procore::RequestableTest < Minitest::Test
   def test_get_with_company_id
     request = stub_request(:get, "http://test.com/rest/v1.0/home")
       .with(
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => "application/json",
-          "procore-company-id" => "1",
-        },
+        headers: headers.merge("procore-company-id" => "1")
       )
       .to_return(status: 200, body: "", headers: {})
 
@@ -244,12 +214,7 @@ class Procore::RequestableTest < Minitest::Test
     request = stub_request(:post, "http://test.com/rest/v1.0/home")
       .with(
         body: { name: "Name" },
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => "application/json",
-          "procore-company-id" => "1",
-        },
+        headers: headers.merge("procore-company-id" => "1"),
       )
       .to_return(status: 200, body: "", headers: {})
 
@@ -265,11 +230,7 @@ class Procore::RequestableTest < Minitest::Test
   def test_post_with_multipart_body
     request = stub_request(:post, "http://test.com/rest/v1.0/home")
       .with(
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => %r[multipart/form-data],
-        },
+        headers: headers.merge("Content-Type" => %r[multipart/form-data]),
       )
       .to_return(status: 200, body: "", headers: {})
 

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -39,6 +39,19 @@ class Procore::RequestableTest < Minitest::Test
     assert_requested request
   end
 
+  def test_rest_get
+    request = stub_request(:get, "http://test.com/rest/v1.1/home")
+      .with(
+        query: { per_page: 5 },
+        headers: headers
+      )
+      .to_return(status: 200, body: "", headers: {})
+
+    Request.new(token: "token").get("rest/v1.1/home", query: { per_page: 5 })
+
+    assert_requested request
+  end
+
   def test_vapid_get
     request = stub_request(:get, "http://test.com/vapid/home")
       .with(
@@ -56,15 +69,24 @@ class Procore::RequestableTest < Minitest::Test
     request = stub_request(:post, "http://test.com/rest/v1.0/home")
       .with(
         body: { name: "Name" },
-        headers: {
-          "Accepts" => "application/json",
-          "Authorization" => "Bearer token",
-          "Content-Type" => "application/json",
-        },
+        headers: headers
       )
       .to_return(status: 200, body: "", headers: {})
 
     Request.new(token: "token").post("home", body: { name: "Name" })
+
+    assert_requested request
+  end
+
+  def test_rest_post
+    request = stub_request(:post, "http://test.com/rest/v1.1/home")
+      .with(
+        body: { name: "Name" },
+        headers: headers
+      )
+      .to_return(status: 200, body: "", headers: {})
+
+    Request.new(token: "token").post("rest/v1.1/home", body: { name: "Name" })
 
     assert_requested request
   end
@@ -94,6 +116,20 @@ class Procore::RequestableTest < Minitest::Test
 
     assert_requested request
   end
+
+  def test_rest_put
+    request = stub_request(:put, "http://test.com/rest/v1.1/home")
+      .with(
+        body: { name: "Replaced Name" },
+        headers: headers
+      )
+      .to_return(status: 200, body: "", headers: {})
+
+    Request.new(token: "token").put("rest/v1.1/home", body: { name: "Replaced Name" })
+
+    assert_requested request
+  end
+
 
   def test_vapid_put
     request = stub_request(:put, "http://test.com/vapid/home")

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -4,14 +4,17 @@ class Procore::RequestableTest < Minitest::Test
   class Request
     include Procore::Requestable
 
-    attr_reader :access_token, :api_version
-    def initialize(token:, api_version: 'vapid')
+    attr_reader :access_token
+    def initialize(token:)
       @access_token = token
-      @api_version = api_version
+    end
+
+    def base_api_path
+      "http://test.com"
     end
 
     def base_api_default_path
-      "http://test.com/#{@api_version}"
+      "#{base_api_path}/vapid"
     end
   end
 
@@ -44,7 +47,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token", api_version: 'rest').get("home", query: { per_page: 5 })
+    Request.new(token: "token").get("rest/home", query: { per_page: 5 })
 
     assert_requested request
   end
@@ -78,7 +81,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token", api_version: 'rest').post("home", body: { name: "Name" })
+    Request.new(token: "token").post("rest/home", body: { name: "Name" })
 
     assert_requested request
   end
@@ -112,7 +115,7 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token", api_version: 'rest').put("home", body: { name: "Replaced Name" })
+    Request.new(token: "token").put("rest/home", body: { name: "Replaced Name" })
 
     assert_requested request
   end

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -14,12 +14,12 @@ class Procore::RequestableTest < Minitest::Test
     end
 
     def base_api_default_path
-      "#{base_api_path}/vapid"
+      "#{base_api_path}/rest/v1.0"
     end
   end
 
   def test_get
-    request = stub_request(:get, "http://test.com/vapid/home")
+    request = stub_request(:get, "http://test.com/rest/v1.0/home")
       .with(
         query: { per_page: 5 },
         headers: {
@@ -35,8 +35,8 @@ class Procore::RequestableTest < Minitest::Test
     assert_requested request
   end
 
-  def test_rest_get
-    request = stub_request(:get, "http://test.com/rest/home")
+  def test_vapid_get
+    request = stub_request(:get, "http://test.com/vapid/home")
       .with(
         query: { per_page: 5 },
         headers: {
@@ -47,13 +47,13 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").get("rest/home", query: { per_page: 5 })
+    Request.new(token: "token").get("vapid/home", query: { per_page: 5 })
 
     assert_requested request
   end
 
   def test_post
-    request = stub_request(:post, "http://test.com/vapid/home")
+    request = stub_request(:post, "http://test.com/rest/v1.0/home")
       .with(
         body: { name: "Name" },
         headers: {
@@ -69,8 +69,8 @@ class Procore::RequestableTest < Minitest::Test
     assert_requested request
   end
 
-  def test_rest_post
-    request = stub_request(:post, "http://test.com/rest/home")
+  def test_vapid_post
+    request = stub_request(:post, "http://test.com/vapid/home")
       .with(
         body: { name: "Name" },
         headers: {
@@ -81,13 +81,13 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").post("rest/home", body: { name: "Name" })
+    Request.new(token: "token").post("vapid/home", body: { name: "Name" })
 
     assert_requested request
   end
 
   def test_put
-    request = stub_request(:put, "http://test.com/vapid/home")
+    request = stub_request(:put, "http://test.com/rest/v1.0/home")
       .with(
         body: { name: "Replaced Name" },
         headers: {
@@ -103,8 +103,8 @@ class Procore::RequestableTest < Minitest::Test
     assert_requested request
   end
 
-  def test_rest_put
-    request = stub_request(:put, "http://test.com/rest/home")
+  def test_vapid_put
+    request = stub_request(:put, "http://test.com/vapid/home")
       .with(
         body: { name: "Replaced Name" },
         headers: {
@@ -115,13 +115,13 @@ class Procore::RequestableTest < Minitest::Test
       )
       .to_return(status: 200, body: "", headers: {})
 
-    Request.new(token: "token").put("rest/home", body: { name: "Replaced Name" })
+    Request.new(token: "token").put("vapid/home", body: { name: "Replaced Name" })
 
     assert_requested request
   end
 
   def test_patch
-    request = stub_request(:patch, "http://test.com/vapid/home")
+    request = stub_request(:patch, "http://test.com/rest/v1.0/home")
       .with(
         body: { name: "New Name" },
         headers: {
@@ -138,7 +138,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_delete
-    request = stub_request(:delete, "http://test.com/vapid/home")
+    request = stub_request(:delete, "http://test.com/rest/v1.0/home")
       .with(headers: {
               "Accepts" => "application/json",
               "Authorization" => "Bearer token",
@@ -153,7 +153,7 @@ class Procore::RequestableTest < Minitest::Test
 
   def test_sync
     update1 = [{ id: 4, name: "Updated Project 4" }]
-    request1 = stub_request(:patch, "http://test.com/vapid/projects/sync")
+    request1 = stub_request(:patch, "http://test.com/rest/v1.0/projects/sync")
       .with(body: { company_id: 13, updates: update1 })
       .to_return(
         status: 200,
@@ -165,7 +165,7 @@ class Procore::RequestableTest < Minitest::Test
       )
 
     update2 = [{ id: 0, name: "Updated Project 0" }]
-    request2 = stub_request(:patch, "http://test.com/vapid/projects/sync")
+    request2 = stub_request(:patch, "http://test.com/rest/v1.0/projects/sync")
       .with(body: { company_id: 13, updates: update2 }).to_return(
         status: 200,
         body: {
@@ -200,7 +200,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_post_with_idempotency_token
-    request = stub_request(:post, "http://test.com/vapid/home")
+    request = stub_request(:post, "http://test.com/rest/v1.0/home")
       .with(
         headers: {
           "Accepts" => "application/json",
@@ -221,7 +221,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_get_with_company_id
-    request = stub_request(:get, "http://test.com/vapid/home")
+    request = stub_request(:get, "http://test.com/rest/v1.0/home")
       .with(
         headers: {
           "Accepts" => "application/json",
@@ -241,7 +241,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_post_with_company_id
-    request = stub_request(:post, "http://test.com/vapid/home")
+    request = stub_request(:post, "http://test.com/rest/v1.0/home")
       .with(
         body: { name: "Name" },
         headers: {
@@ -263,7 +263,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_post_with_multipart_body
-    request = stub_request(:post, "http://test.com/vapid/home")
+    request = stub_request(:post, "http://test.com/rest/v1.0/home")
       .with(
         headers: {
           "Accepts" => "application/json",
@@ -281,7 +281,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_unauthorized_error
-    stub_request(:get, "http://test.com/vapid/")
+    stub_request(:get, "http://test.com/rest/v1.0/")
       .to_return(status: 401, body: "", headers: {})
 
     assert_raises Procore::AuthorizationError do
@@ -290,7 +290,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_forbidden_error
-    stub_request(:get, "http://test.com/vapid/")
+    stub_request(:get, "http://test.com/rest/v1.0/")
       .to_return(status: 403, body: "", headers: {})
 
     assert_raises Procore::ForbiddenError do
@@ -299,7 +299,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_not_found_error
-    stub_request(:get, "http://test.com/vapid/")
+    stub_request(:get, "http://test.com/rest/v1.0/")
       .to_return(status: 404, body: "", headers: {})
 
     assert_raises Procore::NotFoundError do
@@ -308,7 +308,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_server_error
-    stub_request(:get, "http://test.com/vapid/")
+    stub_request(:get, "http://test.com/rest/v1.0/")
       .to_return(status: 500, body: "", headers: {})
 
     assert_raises Procore::ServerError do
@@ -317,7 +317,7 @@ class Procore::RequestableTest < Minitest::Test
   end
 
   def test_error_body
-    stub_request(:get, "http://test.com/vapid/")
+    stub_request(:get, "http://test.com/rest/v1.0/")
       .to_return(
         status: 401,
         body: { errors: "Unauthorized" }.to_json,

--- a/test/procore/response_test.rb
+++ b/test/procore/response_test.rb
@@ -27,11 +27,13 @@ class Procore::Response::BodyTest < Minitest::Test
     assert_equal(response_body, response.body)
   end
 
-  def test_response_pagination_parsing
-    links = '<http://localhost:3000/vapid/projects?page=1>; rel="first", '\
-      '<http://localhost:3000/vapid/projects?page=173>; rel="last", '\
-      '<http://localhost:3000/vapid/projects?page=6>; rel="next", '\
-      '<http://localhost:3000/vapid/projects?page=4>; rel="prev"'
+  def shared_response_pagination_parsing_test(base_path)
+    links = %W(
+      <#{base_path}/projects?page=1>; rel="first",
+      <#{base_path}/projects?page=173>; rel="last",
+      <#{base_path}/projects?page=6>; rel="next",
+      '#{base_path}/projects?page=4>; rel="prev"
+    ).join(" ")
 
     response = Procore::Response.new(
       body: [{ key: "value" }].to_json,
@@ -52,9 +54,19 @@ class Procore::Response::BodyTest < Minitest::Test
     )
   end
 
-  def test_response_pagination_parsing_on_first_page
-    links = '<http://localhost:3000/vapid/projects?page=173>; rel="last", '\
-      '<http://localhost:3000/vapid/projects?page=6>; rel="next"'
+  def test_rest_response_pagination_parsing
+    shared_response_pagination_parsing_test("http://localhost:3000/rest/v1.0")
+  end
+
+  def test_vapid_response_pagination_parsing
+      shared_response_pagination_parsing_test("http://localhost:3000/vapid")
+  end
+
+  def shared_response_pagination_parsing_on_first_page(base_path)
+    links = %W(
+      <#{base_path}/projects?page=173>; rel="last",
+      <#{base_path}/projects?page=6>; rel="next"
+    ).join(" ")
 
     response = Procore::Response.new(
       body: [{ key: "value" }].to_json,
@@ -71,6 +83,14 @@ class Procore::Response::BodyTest < Minitest::Test
       },
       response.pagination,
     )
+  end
+
+  def test_vapid_response_pagination_parsing_on_first_page
+    shared_response_pagination_parsing_on_first_page("http://localhost:3000/vapid")
+  end
+
+  def test_rest_response_pagination_parsing_on_first_page
+    shared_response_pagination_parsing_on_first_page("http://localhost:3000/rest/v1.0")
   end
 
   def test_response_pagination_no_links

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,5 +8,4 @@ require "procore"
 
 Procore.configure do |config|
   config.host = "https://procore.example.com"
-  config.default_version = "v1.0"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,4 +8,5 @@ require "procore"
 
 Procore.configure do |config|
   config.host = "https://procore.example.com"
+  config.default_version = "v1.0"
 end


### PR DESCRIPTION
Ticket: [ZL-751](https://procoretech.atlassian.net/browse/ZL-751)

# Description
This PR changes how the SDK handles API versions, to support easy migration from the legacy API Vapid to the new versioned API Rest. Read more about the Rest versioned API in our [Confluence pages](https://procoretech.atlassian.net/wiki/spaces/DEV/pages/1360265934/Procore+Rest+API).


An optional `default_version` can now be set during configuration, and should be either `v1.0` (recommended) or `vapid` (legacy). If no default version is provided, it is automatically set to `v1.0`.

```ruby
Procore.configure do |config|
  ...
  config.default_version = "v1.0"
  ...
end
```

The API version can also be specified at the time of the request.

| Example | Requested URL |
| --- | --- |
| `client.get("me")` | `https://app.procore.com/rest/v1.0/me` |
| `client.get("me", version: "v1.1")` | `https://app.procore.com/rest/v1.1/me` |
| `client.get("me", version: "vapid")` | `https://app.procore.com/vapid/me` |

## Bonus
Fixes TravisCI by resolving Rubocop errors caused by outdated `.rubocop.yml` and missing gems.