### PR TITLE
[ZL-874] Manually refresh and revoke tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0 (March 4, 2021)
+## Unreleased
 
 * Allow tokens to be revoked and manually refreshed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0 (March 4, 2021)
+
+* Allow tokens to be revoked and manually refreshed.
+
+  PR #39 - https://github.com/procore/ruby-sdk/pull/39
+
+  *Nate Baer*
+
 ## 1.0.0 (January 5, 2021)
 
 * Adds support for API versioning

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ Expired tokens will automatically be refreshed, but can also be refreshed manual
 client.refresh
 ```
 
+Tokens may also be manually revoked, forcing the client to refresh its token on the next request:
+
+```ruby
+client.revoke
+```
+
 ## Error Handling
 
 The Procore Gem raises errors whenever a request returns a non `2xx` response.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ client = Procore::Client.new(
 client.get("me")
 ```
 
+Expired tokens will automatically be refreshed, but can also be refreshed manually:
+
+```ruby
+client.refresh
+```
+
 ## Error Handling
 
 The Procore Gem raises errors whenever a request returns a non `2xx` response.

--- a/lib/procore/auth/access_token_credentials.rb
+++ b/lib/procore/auth/access_token_credentials.rb
@@ -38,7 +38,7 @@ module Procore
           client_secret: @client_secret,
           token: token.access_token,
         }
-        RestClient.post("#{host}/oauth/revoke", request.to_json)
+        client.request(:post, "/oauth/revoke", body: request)
       rescue RestClient::ExceptionWithResponse
         raise OAuthError.new(e.description, response: e.response)
       end

--- a/lib/procore/auth/access_token_credentials.rb
+++ b/lib/procore/auth/access_token_credentials.rb
@@ -32,6 +32,17 @@ module Procore
         end
       end
 
+      def revoke(token:)
+        request = {
+          client_id: @client_id,
+          client_secret: @client_secret,
+          token: token.access_token,
+        }
+        RestClient.post("#{host}/oauth/revoke", request.to_json)
+      rescue RestClient::ExceptionWithResponse
+        raise OAuthError.new(e.description, response: e.response)
+      end
+
       private
 
       def client

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -62,6 +62,23 @@ module Procore
       end
     end
 
+    def revoke
+      token = fetch_token
+
+      begin
+        @credentials.revoke(token: token)
+        Util.log_info("Token Revocation Successful", store: store)
+      rescue RuntimeError
+        Util.log_error("Token Revocation Failed", store: store)
+        raise Procore::OAuthError.new(
+          "Unable to revoke the access token. Perhaps the Procore API is "  \
+          "down or the your access token store is misconfigured. Either "    \
+          "way, you should clear the store and prompt the user to sign in "  \
+          "again.",
+        )
+      end
+    end
+
     private
 
     def base_api_path

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -39,7 +39,6 @@ module Procore
     end
 
     # @raise [OAuthError] if a token cannot be refreshed.
-    # @raise [OAuthError] if incorrect credentials have been supplied.
     def refresh
       token = fetch_token
 
@@ -62,6 +61,7 @@ module Procore
       end
     end
 
+    # @raise [OAuthError] if a token cannot be revoked.
     def revoke
       token = fetch_token
 

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -55,7 +55,7 @@ module Procore
         Util.log_error("Token Refresh Failed", store: store)
         raise Procore::OAuthError.new(
           "Unable to refresh the access token. Perhaps the Procore API is "  \
-          "down or the your access token store is misconfigured. Either "    \
+          "down or your access token store is misconfigured. Either "    \
           "way, you should clear the store and prompt the user to sign in "  \
           "again.",
         )
@@ -72,7 +72,7 @@ module Procore
         Util.log_error("Token Revocation Failed", store: store)
         raise Procore::OAuthError.new(
           "Unable to revoke the access token. Perhaps the Procore API is "  \
-          "down or the your access token store is misconfigured. Either "    \
+          "down or your access token store is misconfigured. Either "    \
           "way, you should clear the store and prompt the user to sign in "  \
           "again.",
         )

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -374,7 +374,7 @@ module Procore
       elsif /\Av\d+\.\d+\z/.match?(version)
         File.join(base_api_path, "rest", version, path)
       else
-        raise ArgumentError.new "'#{version}' is an invalid Procore API version"
+        raise Procore::InvalidRequestError.new "#{version} is an invalid Procore API version"
       end
     end
   end

--- a/lib/procore/version.rb
+++ b/lib/procore/version.rb
@@ -1,3 +1,3 @@
 module Procore
-  VERSION = "1.0.0".freeze
+  VERSION = "1.1.0".freeze
 end

--- a/lib/procore/version.rb
+++ b/lib/procore/version.rb
@@ -1,3 +1,3 @@
 module Procore
-  VERSION = "1.1.0".freeze
+  VERSION = "1.0.0".freeze
 end

--- a/test/procore/client_test.rb
+++ b/test/procore/client_test.rb
@@ -82,4 +82,25 @@ class Procore::ClientTest < Minitest::Test
       client.get("me")
     end
   end
+
+  def test_client_token_refresh
+    stub_refresh_token
+
+    user = User.create(
+      access_token: "token",
+      refresh_token: "refresh",
+      expires_at: 2.hours.from_now,
+    )
+
+    store = Procore::Auth::Stores::ActiveRecord.new(object: user)
+    client = Procore::Client.new(
+      client_id: "client id",
+      client_secret: "client secret",
+      store: store,
+    )
+
+    client.refresh
+
+    assert_requested stub_refresh_token
+  end
 end

--- a/test/procore/client_test.rb
+++ b/test/procore/client_test.rb
@@ -103,4 +103,25 @@ class Procore::ClientTest < Minitest::Test
 
     assert_requested stub_refresh_token
   end
+
+  def test_client_token_revoke
+    stub_revoke_token
+
+    user = User.create(
+      access_token: "token",
+      refresh_token: "refresh",
+      expires_at: 2.hours.from_now,
+    )
+
+    store = Procore::Auth::Stores::ActiveRecord.new(object: user)
+    client = Procore::Client.new(
+      client_id: "client id",
+      client_secret: "client secret",
+      store: store,
+    )
+
+    client.revoke
+
+    assert_requested stub_revoke_token
+  end
 end

--- a/test/support/auth_stubs.rb
+++ b/test/support/auth_stubs.rb
@@ -22,4 +22,8 @@ module AuthStubs
         headers: { "Content-Type" => "application/json" },
       )
   end
+
+  def stub_revoke_token
+    stub_request(:post, "https://procore.example.com/oauth/revoke").to_return(status: 200)
+  end
 end


### PR DESCRIPTION
Ticket: [ZL-874](https://procoretech.atlassian.net/browse/ZL-874)

This PR adds functionality to allow clients to manually refresh and revoke their token.

Pretty simple:
```ruby
client = Procore::Client.new( ... )
client.refresh
client.revoke # client will refresh token on its next request
```