### PR TITLE
Change default host to api.procore.com

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Include:
     - '**/Rakefile'
     - '**/config.ru'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Change default host to 'api.procore.com'.
+
+  *Nate Baer*
+
 ## 1.1.0 (March 11, 2021)
 
 * Allow tokens to be revoked and manually refreshed.

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ default version is `v1.0` unless otherwise configured.
 
 | Example | Requested URL |
 | --- | --- |
-| `client.get("me")` | `https://app.procore.com/rest/v1.0/me` |
-| `client.get("me", version: "v1.1")` | `https://app.procore.com/rest/v1.1/me` |
-| `client.get("me", version: "vapid")` | `https://app.procore.com/vapid/me` |
+| `client.get("me")` | `https://api.procore.com/rest/v1.0/me` |
+| `client.get("me", version: "v1.1")` | `https://api.procore.com/rest/v1.1/me` |
+| `client.get("me", version: "vapid")` | `https://api.procore.com/vapid/me` |
 
 Example Usage:
 
@@ -355,7 +355,7 @@ Procore.configure do |config|
   # Base API host name. Alter this depending on your environment - in a
   # staging or test environment you may want to point this at a sandbox
   # instead of production.
-  config.host = ENV.fetch("PROCORE_BASE_API_PATH", "https://app.procore.com")
+  config.host = ENV.fetch("PROCORE_BASE_API_PATH", "https://api.procore.com")
 
   # When using #sync action, sets the default batch size to use for chunking
   # up a request body. Example: if the size is set to 500, and 2,000 updates

--- a/lib/procore/defaults.rb
+++ b/lib/procore/defaults.rb
@@ -4,7 +4,7 @@ module Procore
   # Specifies some sensible defaults for certain configurations + clients
   class Defaults
     # Default API endpoint
-    API_ENDPOINT = "https://app.procore.com".freeze
+    API_ENDPOINT = "https://api.procore.com".freeze
 
     # Default User Agent header string
     USER_AGENT = "Procore Ruby Gem #{Procore::VERSION}".freeze


### PR DESCRIPTION
Fixes https://github.com/procore/ruby-sdk/issues/41

The default host should be `api.procore.com` not `app.procore.com`.