### PR TITLE
Break up sdk header into language and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+* Add Procore-Sdk-Language header to all requests
+
+  PR #45 - https://github.com/procore/ruby-sdk/pull/45
+
+  *Benjamin Ross*
+
 ## 1.1.2 (Jun 4, 2021)
 
 * Add Procore-Sdk-Version header to all requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+## Unreleased
 
 * Add Procore-Sdk-Language header to all requests
 

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -343,7 +343,8 @@ module Procore
         "Accepts" => "application/json",
         "Authorization" => "Bearer #{access_token}",
         "Content-Type" => "application/json",
-        "Procore-Sdk-Version" => "ruby-#{Procore::VERSION}",
+        "Procore-Sdk-Version" => Procore::VERSION,
+        "Procore-Sdk-Language" => "ruby",
         "User-Agent" => Procore.configuration.user_agent,
       }.tap do |headers|
         if options[:idempotency_token]

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -26,7 +26,8 @@ class Procore::RequestableTest < Minitest::Test
       "Accepts" => "application/json",
       "Authorization" => "Bearer token",
       "Content-Type" => "application/json",
-      "Procore-Sdk-Version" => "ruby-#{Procore::VERSION}",
+      "Procore-Sdk-Version" => Procore::VERSION,
+      "Procore-Sdk-Language" => "ruby",
     }
   end
 


### PR DESCRIPTION
https://procoretech.atlassian.net/browse/ZL-1055

Break up `Procore-Sdk-Version` to send language in `Procore-Sdk-Language`