### PR TITLE
Remove Redis.exists warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+* Remove Redis.exists warning
+
+  PR #46 - https://github.com/procore/ruby-sdk/pull/46
+
+  *claudioprocore*
+
 ## 1.1.2 (Jun 4, 2021)
 
 * Add Procore-Sdk-Version header to all requests

--- a/lib/procore/auth/stores/redis.rb
+++ b/lib/procore/auth/stores/redis.rb
@@ -13,7 +13,7 @@ module Procore
         end
 
         def fetch
-          return unless redis.exists(redis_key)
+          return unless redis.exists?(redis_key)
 
           token = JSON.parse(redis.get(redis_key))
           Procore::Auth::Token.new(


### PR DESCRIPTION
This commit removes the following warning when using the gem

> `Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?`
> returns a boolean, you should use it instead. To opt-in to the new behavior
> now you can set Redis.exists_returns_integer =  true. To disable this message
> and keep the current (boolean) behaviour of 'exists' you can set
> `Redis.exists_returns_integer = false`, but this option will be removed in 5.0.