### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ client = Procore::Client.new(
 )
 
 # Get the current user's companies
-companies = client.get("companies")
+companies = client.get("companies").body
 
 companies.first[:name] #=> "Procore Company 1"
 
 # Get a company's projects (note the company_id value in options)
-projects = client.get("projects", query: {company_id: <company_id>}, options: {company_id: <company_id>})
+projects = client.get("projects", query: {company_id: <company_id>}, options: {company_id: <company_id>}).body
 
 projects.first[:name] #=> "Project 1"
 ```


### PR DESCRIPTION
`client.get` returns an instance of `Procore::Response` which does not have a `first` method.

If that's expected, this commit updates the documentation accordingly.
If that's a bug, then ignore this commit.