### PR TITLE
Fix regex pagination issue

### DIFF
--- a/lib/procore/response.rb
+++ b/lib/procore/response.rb
@@ -72,7 +72,7 @@ module Procore
 
     def parse_pagination
       headers[:link].to_s.split(", ").map(&:strip).reduce({}) do |links, link|
-        url, name = link.match(/(?:vapid|rest\/.*?)\/(.*?)>; rel="(\w+)"/).captures
+        url, name = link.match(/(?:vapid|api|rest)(?:\/?.*?)\/(.*?)>; rel="(\w+)"/).captures
         links.merge!(name.to_sym => url)
       end
     end

--- a/test/procore/response_test.rb
+++ b/test/procore/response_test.rb
@@ -62,6 +62,10 @@ class Procore::Response::BodyTest < Minitest::Test
       shared_response_pagination_parsing_test("http://localhost:3000/vapid")
   end
 
+  def test_login_response_pagination_parsing
+      shared_response_pagination_parsing_test("http://localhost:3000/api/v1")
+  end
+
   def shared_response_pagination_parsing_on_first_page(base_path)
     links = %W(
       <#{base_path}/projects?page=173>; rel="last",


### PR DESCRIPTION
The regex for parsing pagination urls does not work when interacting with our internal urls.

This changes the regex to match `vapid|api|rest` and then match any version string that may or may not come after the api slug.