### PR TITLE
[AGX-814] Fix bugs with token refresh and Oauth2 URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Fix a bug with automatic token refreshing where the expired token would still be used for the first request.
 
+* Fix requests made to incorrect URL when using newer versions of Oauth2
+
   *Nate Baer*
 
 ## 1.1.3 (Jun 11, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Fix a bug with automatic token refreshing where the expired token would still be used for the first request.
+
+  *Nate Baer*
+
 ## 1.1.3 (Jun 11, 2021)
 
 * Add Procore-Sdk-Language header to all requests

--- a/lib/procore/auth/access_token_credentials.rb
+++ b/lib/procore/auth/access_token_credentials.rb
@@ -49,7 +49,7 @@ module Procore
         OAuth2::Client.new(
           client_id,
           client_secret,
-          site: "#{host}/oauth/token",
+          site: host,
         )
       end
     end

--- a/lib/procore/auth/client_credentials.rb
+++ b/lib/procore/auth/client_credentials.rb
@@ -43,7 +43,7 @@ module Procore
         OAuth2::Client.new(
           client_id,
           client_secret,
-          site: "#{host}/oauth/token",
+          site: host,
         )
       end
     end

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -103,6 +103,7 @@ module Procore
       if token.expired?
         Util.log_info("Token Expired", store: store)
         refresh
+        token = fetch_token
       end
       token.access_token
     end


### PR DESCRIPTION
This PR contains two bug fixes for the Procore Ruby SDK:

### Fix token refresh

When a token was automatically refreshed, the first request would fail. The token is now updated in memory so this will not occur.

Resolves issue: https://github.com/procore/ruby-sdk/issues/51

### Fix Oauth2 URL

The path fragment `/oauth/token` was incorrectly inserted into the `host` URL when the Oauth2 client is initialized. Older versions of Oauth2 apparently stripped this out, but not the recent version I was using.