### PR TITLE
SimpleCov report fix

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,3 @@
-require "minitest/autorun"
-require "webmock/minitest"
-
-require "support/auth_stubs"
-require "support/database"
-
-require "procore"
-
 # For code coverage measurements to work properly, `SimpleCov` should be loaded
 # and started before any application code is loaded.
 if ENV["COVERAGE"]
@@ -18,8 +10,17 @@ if ENV["COVERAGE"]
 
   SimpleCov.start do
     track_files "lib/**/*.{rb}"
+    add_filter "test/"
   end
 end
+
+require "minitest/autorun"
+require "webmock/minitest"
+
+require "support/auth_stubs"
+require "support/database"
+
+require "procore"
 
 Procore.configure do |config|
   config.host = "https://procore.example.com"


### PR DESCRIPTION
SimpleCov was showing zero coverage for the repository, even though we had tests. This PR fixes the test_helper.rb, simplecov now generates accurate coverage that can be pushed to sonarqube.

SimpleCov needs to be [launched before any application code](https://github.com/simplecov-ruby/simplecov#getting-started) in test_helper.rb for it to work. Else it generates zero coverage. 

Completed testing locally, Coverage numbers are being generated now.