### PR TITLE
add login_host option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3 (Jan 8, 2024)
+
+* Introduces :login_host configuration attribute used to set up OAuth2::Client. Please note, this will result Procore::Client use `https://login.procore.com/oauth/token` instead of `https://api.procore.com/oauth/token` for auth token generation.   
+
+  *Eugene Tokarev*
+
 ## 1.2 (Dec 8, 2022)
 
 * Update oauth2 gem version to any 2.x

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Procore.configure do |config|
   # instead of production.
   config.host = ENV.fetch("PROCORE_BASE_API_PATH", "https://api.procore.com")
 
+  # Base Login host name used by the OAuth client to generate API tokens.
+  # Alter this depending on your environment - in a staging or test environment
+  # you may want to point this at a sandbox instead of production.
+  config.login_host = ENV.fetch("PROCORE_BASE_LOGIN_PATH", "https://login.procore.com")
+
   # When using #sync action, sets the default batch size to use for chunking
   # up a request body. Example: if the size is set to 500, and 2,000 updates
   # are desired, 4 requests will be made. Note, the maximum size is 1000.

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -26,11 +26,12 @@ module Procore
     # @param options [Hash] options to configure the client with
     # @option options [String] :host Endpoint to use for the API. Defaults to
     #   Configuration.host
+    # @option options [String] :login_host used by the OAuth client to generate API tokens.
+    # Defaults to Configuration.login_host
     # @option options [String] :user_agent User Agent string to send along with
     #   the request. Defaults to Configuration.user_agent
     def initialize(client_id:, client_secret:, store:, options: {})
       @options = Procore::Defaults::client_options.merge(options)
-
       @credentials = Procore::Auth::AccessTokenCredentials.new(
         client_id: client_id,
         client_secret: client_secret,

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -31,11 +31,10 @@ module Procore
     def initialize(client_id:, client_secret:, store:, options: {})
       @options = Procore::Defaults::client_options.merge(options)
 
-      host = @options[:login_host] || @options[:host]
       @credentials = Procore::Auth::AccessTokenCredentials.new(
         client_id: client_id,
         client_secret: client_secret,
-        host: host,
+        host: @options[:login_host],
       )
       @store = store
     end

--- a/lib/procore/client.rb
+++ b/lib/procore/client.rb
@@ -30,10 +30,12 @@ module Procore
     #   the request. Defaults to Configuration.user_agent
     def initialize(client_id:, client_secret:, store:, options: {})
       @options = Procore::Defaults::client_options.merge(options)
+
+      host = @options[:login_host] || @options[:host]
       @credentials = Procore::Auth::AccessTokenCredentials.new(
         client_id: client_id,
         client_secret: client_secret,
-        host: @options[:host],
+        host: host,
       )
       @store = store
     end

--- a/lib/procore/configuration.rb
+++ b/lib/procore/configuration.rb
@@ -111,6 +111,7 @@ module Procore
     def initialize
       @default_batch_size = Procore::Defaults::BATCH_SIZE
       @host = Procore::Defaults::API_ENDPOINT
+      @login_host = Procore::Defaults::LOGIN_ENDPOINT
       @logger = nil
       @max_retries = 1
       @timeout = 1.0

--- a/lib/procore/configuration.rb
+++ b/lib/procore/configuration.rb
@@ -32,6 +32,16 @@ module Procore
     # @return [String]
     attr_accessor :host
 
+    # @!attribute [rw] login_host
+    # @note defaults to Defaults::LOGIN_ENDPOINT
+    #
+    # Base Login host name used by the OAuth client to generate API tokens.
+    # Alter this depending on your environment - in a staging or test environment
+    # you may want to point this at a sandbox instead of production.
+    #
+    # @return [String]
+    attr_accessor :login_host
+
     # @!attribute [rw] default_version
     # @note defaults to Defaults::DEFAULT_VERSION
     #

--- a/lib/procore/defaults.rb
+++ b/lib/procore/defaults.rb
@@ -6,6 +6,9 @@ module Procore
     # Default API endpoint
     API_ENDPOINT = "https://api.procore.com".freeze
 
+    # Default Login endpoint
+    LOGIN_ENDPOINT = "https://login.procore.com".freeze
+
     # Default User Agent header string
     USER_AGENT = "Procore Ruby Gem #{Procore::VERSION}".freeze
 
@@ -18,6 +21,7 @@ module Procore
     def self.client_options
       {
         host: Procore.configuration.host,
+        login_host: Procore.configuration.login_host,
         user_agent: Procore.configuration.user_agent,
         default_version: Procore.configuration.default_version,
       }

--- a/test/procore/client_test.rb
+++ b/test/procore/client_test.rb
@@ -28,6 +28,7 @@ class Procore::ClientTest < Minitest::Test
       store: store,
       options: {
         host: "https://example.com",
+        login_host: "https://my-auth-provider.com",
         default_version: "v1.0",
         user_agent: "Procore Test Suite",
       },
@@ -35,6 +36,7 @@ class Procore::ClientTest < Minitest::Test
 
     assert_equal "https://example.com", client.options[:host]
     assert_equal "Procore Test Suite", client.options[:user_agent]
+    assert_equal "https://my-auth-provider.com", client.options[:login_host]
   end
 
   def test_client_active_recored_expired_token

--- a/test/support/auth_stubs.rb
+++ b/test/support/auth_stubs.rb
@@ -1,5 +1,5 @@
 module AuthStubs
-  def stub_client_credentials_token(host: "https://procore.example.com")
+  def stub_client_credentials_token(host: "https://procore-login.example.com")
     stub_request(:post, "#{host}/oauth/token")
       .to_return(
         status: 200,
@@ -9,7 +9,7 @@ module AuthStubs
   end
 
   def stub_refresh_token
-    stub_request(:post, "https://procore.example.com/oauth/token")
+    stub_request(:post, "https://procore-login.example.com/oauth/token")
       .to_return(
         status: 200,
         body: {
@@ -24,6 +24,6 @@ module AuthStubs
   end
 
   def stub_revoke_token
-    stub_request(:post, "https://procore.example.com/oauth/revoke").to_return(status: 200)
+    stub_request(:post, "https://procore-login.example.com/oauth/revoke").to_return(status: 200)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,4 +24,5 @@ require "procore"
 
 Procore.configure do |config|
   config.host = "https://procore.example.com"
+  config.login_host = "https://procore-login.example.com"
 end


### PR DESCRIPTION
This PR introduces `:login_host` configuration value used to set up OAuth2::Client. 

The work is done to migrate SDK users from calling `https://api.procore.com/oauth/token` (which is basically a proxcy call in the monolith) to calling the login service directly via `https://login.procore.com/oauth/token`.     

Please see this [Slack thread](https://procoretech.slack.com/archives/C0HMLDAKY/p1703016580126819) for additional details.