### PR TITLE
Fix retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.1 (Jan 9, 2024)
+
+* Fix a bug with the retry logic in `with_response_handling` resulting in performing one more retry than expected .
+
+  *Eugene Tokarev*
+
 ## 1.3 (Jan 8, 2024)
 
 * Introduces :login_host configuration attribute used to set up OAuth2::Client. Please note, this will result Procore::Client use `https://login.procore.com/oauth/token` instead of `https://api.procore.com/oauth/token` for auth token generation.   

--- a/lib/procore/requestable.rb
+++ b/lib/procore/requestable.rb
@@ -253,7 +253,7 @@ module Procore
       begin
         result = yield
       rescue *HTTP_EXCEPTIONS => e
-        if retries <= Procore.configuration.max_retries
+        if retries < Procore.configuration.max_retries
           retries += 1
           sleep 1.5**retries
           retry

--- a/lib/procore/version.rb
+++ b/lib/procore/version.rb
@@ -1,3 +1,3 @@
 module Procore
-  VERSION = "1.3".freeze
+  VERSION = "1.3.1".freeze
 end

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -332,4 +332,23 @@ class Procore::RequestableTest < Minitest::Test
       assert_equal({ "errors" => "Unauthorized" }, e.response.body)
     end
   end
+
+  def test_no_retry_logic
+    # Disable retries
+    max_retries_old = Procore.configuration.max_retries
+    Procore.configuration.max_retries = 0
+
+    stub_request(:get, "http://test.com/rest/v1.0/retry_test")
+      .to_raise(RestClient::Exceptions::Timeout)
+
+    # Attempt to perform the request and assert the correct exception is raised
+    assert_raises(Procore::APIConnectionError) do
+      Request.new(token: "token").get("retry_test")
+    end
+
+    assert_requested :get, "http://test.com/rest/v1.0/retry_test", times: 1
+
+    Procore.configuration.max_retries = max_retries_old
+  end
+
 end

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -336,18 +336,20 @@ class Procore::RequestableTest < Minitest::Test
   def test_no_retry_logic
     # Disable retries
     max_retries_old = Procore.configuration.max_retries
-    Procore.configuration.max_retries = 0
 
-    stub_request(:get, "http://test.com/rest/v1.0/retry_test")
-      .to_raise(RestClient::Exceptions::Timeout)
+    begin
+      Procore.configuration.max_retries = 0
+      stub_request(:get, "http://test.com/rest/v1.0/retry_test")
+        .to_raise(RestClient::Exceptions::Timeout)
 
-    # Attempt to perform the request and assert the correct exception is raised
-    assert_raises(Procore::APIConnectionError) do
-      Request.new(token: "token").get("retry_test")
+      # Attempt to perform the request and assert the correct exception is raised
+      assert_raises(Procore::APIConnectionError) do
+        Request.new(token: "token").get("retry_test")
+      end
+
+      assert_requested :get, "http://test.com/rest/v1.0/retry_test", times: 1
+    ensure
+      Procore.configuration.max_retries = max_retries_old
     end
-
-    assert_requested :get, "http://test.com/rest/v1.0/retry_test", times: 1
-
-    Procore.configuration.max_retries = max_retries_old
   end
 end

--- a/test/procore/requestable_test.rb
+++ b/test/procore/requestable_test.rb
@@ -350,5 +350,4 @@ class Procore::RequestableTest < Minitest::Test
 
     Procore.configuration.max_retries = max_retries_old
   end
-
 end


### PR DESCRIPTION
This PR fixes a bug with the retry logic in `with_response_handling` resulting in performing one more retry than expected .
